### PR TITLE
NativeModules call must be called on react-native

### DIFF
--- a/react-native-fbsdkcore/js-modules/FBSDKGraphRequestManager.ios.js
+++ b/react-native-fbsdkcore/js-modules/FBSDKGraphRequestManager.ios.js
@@ -25,7 +25,7 @@
 
 var invariant = require('invariant');
 
-var FBSDKNativeGraphRequestManager = require('NativeModules').FBSDKGraphRequestManager;
+var FBSDKNativeGraphRequestManager = require('react-native').NativeModules.FBSDKGraphRequestManager;
 
 import type * as FBSDKGraphRequest from './FBSDKGraphRequest.ios.js';
 


### PR DESCRIPTION
This is how is is done in the other files. This file throws an error in the terminal because
`NativeModules` is not available.