### PR TITLE
adding support for iOS 9.0 schemes

### DIFF
--- a/Sample/iOS/Info.plist
+++ b/Sample/iOS/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>fb-messenger-api</string>
+		<string>fbauth2</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
As per https://developers.facebook.com/docs/ios/ios9.

Otherwise, we're getting errors such as `FBSDKLog: fbauth2 is missing from your Info.plist under LSApplicationQueriesSchemes and is required for iOS 9.0`