### PR TITLE
All fixes needed to get Sample app working with react-native 0.12.0-rc and iOS9

### DIFF
--- a/Sample/iOS/AppDelegate.m
+++ b/Sample/iOS/AppDelegate.m
@@ -38,7 +38,7 @@
    * on the same Wi-Fi network.
    */
 
-  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/index.ios.bundle"];
+  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/index.ios.bundle?platform=ios"];
 
   /**
    * OPTION 2
@@ -54,7 +54,9 @@
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"NHSample"
+                                               initialProperties:nil
                                                    launchOptions:launchOptions];
+
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [[UIViewController alloc] init];

--- a/Sample/iOS/Info.plist
+++ b/Sample/iOS/Info.plist
@@ -56,5 +56,51 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+  
+  
+  
+  <!-- Step 2 Whitelist facebook servers -->
+  
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSExceptionDomains</key>
+    <dict>
+      <key>facebook.com</key>
+      <dict>
+        <key>NSIncludesSubdomains</key> <true/>
+        <key>NSExceptionRequiresForwardSecrecy</key> <false/>
+      </dict>
+      <key>fbcdn.net</key>
+      <dict>
+        <key>NSIncludesSubdomains</key> <true/>
+        <key>NSExceptionRequiresForwardSecrecy</key>  <false/>
+      </dict>
+      <key>akamaihd.net</key>
+      <dict>
+        <key>NSIncludesSubdomains</key> <true/>
+        <key>NSExceptionRequiresForwardSecrecy</key> <false/>
+      </dict>
+    </dict>
+  </dict>
+  
+  <!-- Step 3 Whitelist Facebook Apps -->
+  <key>LSApplicationQueriesSchemes</key>
+  <array>
+    <string>fbapi</string>
+    <string>fb-messenger-api</string>
+    <string>fbauth2</string>
+    <string>fbshareextension</string>
+  </array>
+  
+  <!-- Enable http connections -->
+  
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
+
+
+
 </dict>
 </plist>

--- a/Sample/package.json
+++ b/Sample/package.json
@@ -6,9 +6,9 @@
     "start": "node_modules/react-native/packager/packager.sh"
   },
   "dependencies": {
-    "react-native": "^0.9.0",
-    "react-native-fbsdklogin": "file:../react-native-fbsdklogin/",
+    "react-native": "^v0.12.0-rc",
     "react-native-fbsdkcore": "file:../react-native-fbsdkcore/",
+    "react-native-fbsdklogin": "file:../react-native-fbsdklogin/",
     "react-native-fbsdkshare": "file:../react-native-fbsdkshare/"
   }
 }

--- a/react-native-fbsdkcore/js/FBSDKGraphRequest.ios.js
+++ b/react-native-fbsdkcore/js/FBSDKGraphRequest.ios.js
@@ -109,7 +109,8 @@ class FBSDKGraphRequest {
    * Starts the Graph API request.
    */
   start(timeout: ?number) {
-    FBSDKGraphRequestManager.batchRequests([this], function(){}, 60);
+    timeout = timeout ? timeout : 60;
+    FBSDKGraphRequestManager.batchRequests([this], function(){}, timeout);
   }
 }
 

--- a/react-native-fbsdkcore/js/FBSDKGraphRequest.ios.js
+++ b/react-native-fbsdkcore/js/FBSDKGraphRequest.ios.js
@@ -109,7 +109,7 @@ class FBSDKGraphRequest {
    * Starts the Graph API request.
    */
   start(timeout: ?number) {
-    FBSDKGraphRequestManager.batchRequests([this], null, timeout);
+    FBSDKGraphRequestManager.batchRequests([this], function(){}, 60);
   }
 }
 

--- a/react-native-fbsdkcore/package.json
+++ b/react-native-fbsdkcore/package.json
@@ -8,7 +8,7 @@
     "url": "http://github.com/cphackm"
   },
   "peerDependencies": {
-    "react-native": ">=0.8.0"
+    "react-native": "^v0.12.0-rc"
   },
   "homepage": "https://github.com/facebook/react-native-fbsdk/",
   "keywords": [

--- a/react-native-fbsdklogin/package.json
+++ b/react-native-fbsdklogin/package.json
@@ -8,7 +8,7 @@
     "url": "http://github.com/cphackm"
   },
   "peerDependencies": {
-    "react-native": ">=0.8.0"
+    "react-native": "^v0.12.0-rc"
   },
   "homepage": "https://github.com/facebook/react-native-fbsdk/",
   "keywords": [

--- a/react-native-fbsdkshare/package.json
+++ b/react-native-fbsdkshare/package.json
@@ -8,7 +8,7 @@
     "url": "http://github.com/cphackm"
   },
   "peerDependencies": {
-    "react-native": ">=0.8.0"
+    "react-native": "^v0.12.0-rc"
   },
   "homepage": "https://github.com/facebook/react-native-fbsdk/",
   "keywords": [


### PR DESCRIPTION
…c and iOS9.
I'm pushing this because I've seen people can't make Sample App work in iOS9. 
Do we want to keep this repo up to date with the latests versions ? 
The ugliest change it's in 
 ./node_modules/react-native-fbsdkcore/js/FBSDKGraphRequest.ios.js  like 112 