### PR TITLE
Update peerDependency requirements

### DIFF
--- a/react-native-fbsdkcore/package.json
+++ b/react-native-fbsdkcore/package.json
@@ -8,7 +8,7 @@
     "url": "http://github.com/cphackm"
   },
   "peerDependencies": {
-    "react-native": "^v0.13.0"
+    "react-native": ">=v0.13.0"
   },
   "homepage": "https://github.com/facebook/react-native-fbsdk/",
   "keywords": [

--- a/react-native-fbsdklogin/package.json
+++ b/react-native-fbsdklogin/package.json
@@ -8,7 +8,7 @@
     "url": "http://github.com/cphackm"
   },
   "peerDependencies": {
-    "react-native": "^v0.13.0"
+    "react-native": ">=v0.13.0"
   },
   "homepage": "https://github.com/facebook/react-native-fbsdk/",
   "keywords": [

--- a/react-native-fbsdkshare/package.json
+++ b/react-native-fbsdkshare/package.json
@@ -8,7 +8,7 @@
     "url": "http://github.com/cphackm"
   },
   "peerDependencies": {
-    "react-native": "^v0.13.0"
+    "react-native": ">=v0.13.0"
   },
   "homepage": "https://github.com/facebook/react-native-fbsdk/",
   "keywords": [


### PR DESCRIPTION
Because ^ only works for all 0.13.x versions. Changing to `>=` will allow them all (note, it will also work when major is bumped, but I am not sure if that's an issue at this point, given the development lifecycle of react-native). 

Can be tested on semver.npmjs.com.

Another possible solutions:
`^v0.x` - all from 0.1.0 until 1.0.0
`0.x` - same as above