### PR TITLE
make applicationID and userID case consistent with iOS

### DIFF
--- a/Android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
+++ b/Android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
@@ -75,8 +75,8 @@ public final class Utility {
     public static WritableMap accessTokenToReactMap(AccessToken accessToken) {
         WritableMap map = Arguments.createMap();
         map.putString("accessToken", accessToken.getToken());
-        map.putString("applicationId", accessToken.getApplicationId());
-        map.putString("userId", accessToken.getUserId());
+        map.putString("applicationID", accessToken.getApplicationId());
+        map.putString("userID", accessToken.getUserId());
         map.putArray("permissions",
                 Arguments.fromJavaArgs(setToStringArray(accessToken.getPermissions())));
         map.putArray("declinedPermissions",


### PR DESCRIPTION
The case of Id is different between Android and iOS, leading to these parts of the token to not be passed through correctly on Android.  