### PR TITLE
Fix: Set SharingContent for MessageDialog.canShow

### DIFF
--- a/iOS/share/iOS/RCTFBSDKMessageDialog.m
+++ b/iOS/share/iOS/RCTFBSDKMessageDialog.m
@@ -54,6 +54,7 @@ RCT_EXPORT_MODULE(FBMessageDialog);
 
 RCT_EXPORT_METHOD(canShow:(RCTFBSDKSharingContent)content resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
+  _dialog.shareContent = content;
   if ([_dialog canShow]) {
     NSError *error;
     if ([_dialog validateWithError:&error]) {


### PR DESCRIPTION
MessageDialog.canShow(ShareContent) would always return an error because the ShareContent wasn't being set in FBSDKMessageDialog.