### PR TITLE
Update android docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Initialize sdk in method `onCreate()`.
 protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     FacebookSdk.sdkInitialize(getApplicationContext());
-    AppEventsLogger.activateApp(this);
 } 
 ```
 Override `onActivityResult()`.
@@ -89,7 +88,7 @@ public void onActivityResult(int requestCode, int resultCode, Intent data) {
     mCallbackManager.onActivityResult(requestCode, resultCode, data);
 }
 ```
-To use [AppEventsLogger](https://developers.facebook.com/docs/app-events), add the activateApp method call on your Application's `onCreate` method:
+To use [AppEventsLogger](https://developers.facebook.com/docs/app-events), add the activateApp method call on your MainActivity `onCreate` method like this:
 ```java
 import com.facebook.appevents.AppEventsLogger;     // <--- import
 

--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ public void onActivityResult(int requestCode, int resultCode, Intent data) {
 }
 ```
 To use [AppEventsLogger](https://developers.facebook.com/docs/app-events), add the activateApp method call on your Application's `onCreate` method:
-```diff
-+ import com.facebook.appevents.AppEventsLogger;     // <--- import
+```java
+import com.facebook.appevents.AppEventsLogger;     // <--- import
 
 @Override
 protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     FacebookSdk.sdkInitialize(getApplicationContext());
-+   AppEventsLogger.activateApp(getApplication());
+    AppEventsLogger.activateApp(getApplication());     // <--- add
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,13 +95,7 @@ import com.facebook.appevents.AppEventsLogger;     // <--- import
 @Override
 protected void onResume() {
     super.onResume();
-    AppEventsLogger.activateApp(getApplicationContext());
-}
-
-@Override
-protected void onPause() {
-    super.onPause();
-    AppEventsLogger.deactivateApp(getApplicationContext());
+    AppEventsLogger.activateApp(getApplication());
 }
 
 @Override

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Initialize sdk in method `onCreate()`.
 protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     FacebookSdk.sdkInitialize(getApplicationContext());
+    AppEventsLogger.activateApp(this);
 } 
 ```
 Override `onActivityResult()`.
@@ -88,20 +89,15 @@ public void onActivityResult(int requestCode, int resultCode, Intent data) {
     mCallbackManager.onActivityResult(requestCode, resultCode, data);
 }
 ```
-To use [AppEventsLogger](https://developers.facebook.com/docs/app-events), add method call to `activateApp`, `deactivateApp` and `onContextStop` in the corresponding life cycle events.
-```java
-import com.facebook.appevents.AppEventsLogger;     // <--- import
+To use [AppEventsLogger](https://developers.facebook.com/docs/app-events), add method call on your Application's `onCreate` method:
+```diff
++ import com.facebook.appevents.AppEventsLogger;     // <--- import
 
 @Override
-protected void onResume() {
-    super.onResume();
-    AppEventsLogger.activateApp(getApplication());
-}
-
-@Override
-protected void onStop() {
-    super.onStop();
-    AppEventsLogger.onContextStop();
+protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    FacebookSdk.sdkInitialize(getApplicationContext());
++    AppEventsLogger.activateApp(getApplication());
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To use [AppEventsLogger](https://developers.facebook.com/docs/app-events), add t
 protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     FacebookSdk.sdkInitialize(getApplicationContext());
-+    AppEventsLogger.activateApp(getApplication());
++   AppEventsLogger.activateApp(getApplication());
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ public void onActivityResult(int requestCode, int resultCode, Intent data) {
     mCallbackManager.onActivityResult(requestCode, resultCode, data);
 }
 ```
-To use [AppEventsLogger](https://developers.facebook.com/docs/app-events), add method call on your Application's `onCreate` method:
+To use [AppEventsLogger](https://developers.facebook.com/docs/app-events), add the activateApp method call on your Application's `onCreate` method:
 ```diff
 + import com.facebook.appevents.AppEventsLogger;     // <--- import
 


### PR DESCRIPTION
On the android documentation of the README.md it says:

> To use AppEventsLogger, add method call to activateApp, deactivateApp and onContextStop in the corresponding life cycle events.

However, after following those steps, my app was crashing  on  com.facebook.appevents.AppEventsLogger.activateApp: 46

so after looking at the code docs, it says that the method has been deprecated and it expects Application instead of context.  

<img width="756" alt="screen shot 2016-05-12 at 5 59 04 pm" src="https://cloud.githubusercontent.com/assets/1247834/15231816/5ce03cb6-186b-11e6-8e24-c9582805ea15.png">

Also, there's no need to override onPause based on this:

<img width="702" alt="screen shot 2016-05-12 at 6 01 11 pm" src="https://cloud.githubusercontent.com/assets/1247834/15231869/a086cb42-186b-11e6-9295-540d8b2e928d.png">

After passing getApplication() instead of getApplicationContext() I was able to build succesfully.

