### PR TITLE
Fix flow issue in FBLoginButton

### DIFF
--- a/js/FBLoginButton.js
+++ b/js/FBLoginButton.js
@@ -38,10 +38,6 @@ import type {
   LoginResult,
 } from './FBLoginManager';
 
-type LoginResultCallback = {
-  error: Object;
-  result: LoginResult;
-};
 type TooltipBehaviorIOS = 'auto' | 'force_display' | 'disable';
 type Event = Object;
 
@@ -69,7 +65,7 @@ class LoginButton extends React.Component {
     /**
      * The callback invoked upon error/completion of a login request.
      */
-    onLoginFinished: (callback: LoginResultCallback) => void;
+    onLoginFinished: (error: Object, result: LoginResult) => void;
 
     /**
      * The callback invoked upon completion of a logout request.


### PR DESCRIPTION
The **onLoginFinished** was typed with a callback of type **LoginResultCallback** (therefore only one parameter), but **onLoginFinished** is used with two parameters at line 108.

There are two solutions to this problem.
The first is to change the call to line 108 in `this.props.onLoginFinished(eventDict)` instead of `this.props.onLoginFinished(eventDict.error, eventDict.result)`

The second is to change the typing of onLoginFinished (like in this pull request).

The first solution is breaking compatibility, the second solution isn't breaking compatibility