### PR TITLE
[README] Get rid of --pre option of CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ protected void onStop() {
 ```
 
 #### 3.2 iOS project
-Assuming you have [CocoaPods](https://cocoapods.org) (it's recommended to use v.1.0+ `gem install cocoapods --pre`) installed, complete the following steps:
+Assuming you have [CocoaPods](https://cocoapods.org) (it's recommended to use v.1.0+ `gem install cocoapods`) installed, complete the following steps:
 
 In `<project name>/ios` directory, create a `Podfile` by running:
 ```ruby


### PR DESCRIPTION
[CocoaPods 1.0](https://github.com/CocoaPods/CocoaPods/releases/tag/1.0.0) has just released so we don't need to use `--pre` option.