### PR TITLE
Fix README on pod integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,15 @@ target 'YourApp' do
 end
 ```
 
-Remove all the subprojects under `Libraries/` in Xcode. This is because React Native's iOS code will be pulled in via CocoaPods.
+Remove these libraries from `Libraries` in Xcode :
+* React.xcodeproj
+* RCTImage.xcodeproj
+* RCTNetwork.xcodeproj
+* RCTText.xcodeproj
+* RCTWebSocket.xcodeproj
+
+This is because React Native's iOS code (Core, RCTImage, RCTNetwork, RCTText and RCTWebSocket) will be pulled in via CocoaPods.
+Others libraries that are included in `../node_modules/react-native/Libraries` must be kept in Libraries folder in Xcode because they're not pulled with CocoaPods.
 
 Run `pod install`. This will automatically download the Facebook SDK for iOS and create an Xcode workspace containing all native files. From now on open `YourApp.xcworkspace` instead of `YourApp.xcodeproj` in Xcode.
 


### PR DESCRIPTION
If we remove all the subprojects under `Libraries/` in Xcode like the README suggest, the app will build successfully but we will run into an issue with libraries that are into `react-native/Libraries` instead of `react-native/React`. These libraries aren't pulled with CocoaPods and some bridge libraries will not work, like in my case the `Linking` one.

I'm not sure if it's the best solution to keep these libraries included into Xcode and the others included via CocoaPods. An other solution would be to add others libraries as separated pod ? But i'm not an iOS expert, any thoughts?

cc @dzhuowen