### PR TITLE
 Append ${SRCROOT}/../../../ios/** to HEADER_SEARCH_PATHS to support finding local FBSDK headers installed via CocoaPods

### DIFF
--- a/iOS/RCTFBSDK.xcodeproj/project.pbxproj
+++ b/iOS/RCTFBSDK.xcodeproj/project.pbxproj
@@ -378,6 +378,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../react/**",
 					"${SRCROOT}/../../react-native/React/**",
+					"${SRCROOT}/../../../ios/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -400,6 +401,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../react/**",
 					"${SRCROOT}/../../react-native/React/**",
+					"${SRCROOT}/../../../ios/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Related to: https://github.com/facebook/react-native-fbsdk/issues/181#issuecomment-221819677