### PR TITLE
Add missing enumerations for FBSDKShareDialogMode

### DIFF
--- a/iOS/RCTFBSDK/share/RCTFBSDKShareDialog.m
+++ b/iOS/RCTFBSDK/share/RCTFBSDKShareDialog.m
@@ -26,8 +26,12 @@
 
 RCT_ENUM_CONVERTER(FBSDKShareDialogMode, (@{
   @"automatic": @(FBSDKShareDialogModeAutomatic),
+  @"native": @(FBSDKShareDialogModeNative),
+  @"share-sheet": @(FBSDKShareDialogModeShareSheet),
   @"browser": @(FBSDKShareDialogModeBrowser),
-  @"webview": @(FBSDKShareDialogModeWeb),
+  @"web": @(FBSDKShareDialogModeWeb),
+  @"feed-browser": @(FBSDKShareDialogModeFeedBrowser),
+  @"feed-web": @(FBSDKShareDialogModeFeedWeb),
 }), FBSDKShareDialogModeAutomatic, unsignedLongValue)
 
 @end


### PR DESCRIPTION
Hey guys,

It seems that not all modes for the `FBSDKShareDialog` are being exposed in `RCTFBSDKShareDialog.m`. That's strange because I was using `react-native-fbsdkshare` and these modes were properly exported (I rely on `feed-web` for an application).

Is there any reason why it's not the case anymore?
This PR updates the converter for `FBSDKShareDialogMode` to expose the enum as done previously by `react-native-fbsdkshare`, following [this Facebook documentation](https://developers.facebook.com/docs/reference/ios/current/constants/FBSDKShareDialogMode/).