### PR TITLE
Add project ios directory to header search paths (allow for vendored or pod installation of sdk)

### DIFF
--- a/ios/RCTFBSDK.xcodeproj/project.pbxproj
+++ b/ios/RCTFBSDK.xcodeproj/project.pbxproj
@@ -384,6 +384,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../react/**",
 					"${SRCROOT}/../../react-native/React/**",
+					"$(PROJECT_DIR)/../../../ios/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -406,6 +407,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../react/**",
 					"${SRCROOT}/../../react-native/React/**",
+					"$(PROJECT_DIR)/../../../ios/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Fix #181 