### PR TITLE
ReAppend /../../../ios/** to HEADER_SEARCH_PATHS for FBSDK pods

### DIFF
--- a/ios/RCTFBSDK.xcodeproj/project.pbxproj
+++ b/ios/RCTFBSDK.xcodeproj/project.pbxproj
@@ -384,6 +384,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../react/**",
 					"${SRCROOT}/../../react-native/React/**",
+					"${SRCROOT}/../../../ios/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -406,6 +407,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../react/**",
 					"${SRCROOT}/../../react-native/React/**",
+					"${SRCROOT}/../../../ios/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
- Original Commit: https://github.com/facebook/react-native-fbsdk/pull/199
- It seems it was lost when the folder was renamed