### PR TITLE
Fixing crash on Android due to new fb SDK version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,5 +23,5 @@ dependencies {
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.1.0'
     compile 'com.facebook.react:react-native:+' // support react-native-v0.22-rc+
-    compile('com.facebook.android:facebook-android-sdk:4.+')
+    compile 'com.facebook.android:facebook-android-sdk:4.16+'
 }


### PR DESCRIPTION
Related to issue : https://github.com/facebook/react-native-fbsdk/issues/310

We had the same issue this morning while trying to build for Android. Seems to be related to new facebook SDK version 4.17.0, and the dependency not strict enough.

There might be a better solution to integrate the new SDK version but this fix is good for a temporary solution.