### PR TITLE
Add 'feed' ShareDialogMode for iOS

### DIFF
--- a/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
@@ -28,6 +28,7 @@ RCT_ENUM_CONVERTER(FBSDKShareDialogMode, (@{
   @"automatic": @(FBSDKShareDialogModeAutomatic),
   @"browser": @(FBSDKShareDialogModeBrowser),
   @"webview": @(FBSDKShareDialogModeWeb),
+  @"feed": @(FBSDKShareDialogModeFeedWeb)
 }), FBSDKShareDialogModeAutomatic, unsignedLongValue)
 
 @end

--- a/js/FBShareDialog.js
+++ b/js/FBShareDialog.js
@@ -54,7 +54,11 @@ type ShareDialogModeIOS =
   /*
    * Displays the dialog in a UIWebView within the app.
    */
-  'webview';
+  'webview'|
+  /*
+   * The feed dialog is used.
+   */
+  'feed';
 
 module.exports = {
   /**


### PR DESCRIPTION
Adds a 'feed' ShareDialogMode to be used with `ShareDialog.setMode`, that translates to iOS’ `FBSDKShareDialogModeFeedWeb`.

The need for this arose from discovering that a behaviour of previous iterations of react-native-fbsdk/FBSDK had disappeared: to specify an `imageURL` for a piece of link content and actually have it show up as the content’s image. In the current version of this package, you can pass a `imageURL` all you like but the share dialog will only ever use an image from the provided `contentURL`.

This seems to be a problem [that others have had with the FBSDK](http://stackoverflow.com/questions/33148544/facebook-share-content-only-shares-url-in-ios-9) since iOS 9, and there’s no way to specify the modes that *do* provide the desired functionality in this package.