### PR TITLE
Fix demo for Android

### DIFF
--- a/sample/HelloFacebook/android/app/src/main/java/com/hellofacebook/MainApplication.java
+++ b/sample/HelloFacebook/android/app/src/main/java/com/hellofacebook/MainApplication.java
@@ -56,7 +56,7 @@ public class MainApplication extends Application implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
-    protected boolean getUseDeveloperSupport() {
+    public boolean getUseDeveloperSupport() {
       return BuildConfig.DEBUG;
     }
 


### PR DESCRIPTION
The sample demo was failing in Android with this error:

```
~/react-native-fbsdk/sample/HelloFacebook/android/app/src/main/java/com/hellofacebook/MainApplication.java:59: error: getUseDeveloperSupport() in <anonymous com.hellofacebook.MainApplication$1> cannot override getUseDeveloperSupport() in ReactNativeHost
    protected boolean getUseDeveloperSupport() {
                      ^
  attempting to assign weaker access privileges; was public
```

That method was changed from `protected` to `public` [here](https://github.com/facebook/react-native/pull/11329). 

This PR fixes it :)