### PR TITLE
Analytics push campaigns support

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,9 @@ const {
 
 // Log a $15 purchase.
 AppEventsLogger.logPurchase(15, 'USD', {'param': 'value'})
+
+// Sets and sends registration id to register the current app for push notifications.
+AppEventsLogger.setPushNotificationsRegistrationId('<registration id>')
 ```
 ### [Graph API](https://developers.facebook.com/docs/graph-api)
 #### Graph Requests

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
@@ -179,6 +179,15 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
     }
 
     /**
+     * Sets and sends registration id to register the current app for push notifications.
+     * @param registrationId RegistrationId received from GCM.
+     */
+    @ReactMethod
+    public static void setPushNotificationsRegistrationId(String registrationId) {
+        AppEventsLogger.setPushNotificationsRegistrationId(registrationId);
+    }
+
+    /**
      * Explicitly flush any stored events to the server.  Implicit flushes may happen depending on
      * the value of getFlushBehavior.  This method allows for explicit, app invoked flushing.
      */

--- a/js/FBAppEventsLogger.js
+++ b/js/FBAppEventsLogger.js
@@ -75,6 +75,14 @@ module.exports = {
   },
 
   /**
+   * Sets and sends registration id to register the current app for push notifications.
+   * @param registrationId RegistrationId received from GCM.
+   */
+  setPushNotificationsRegistrationId(registrationId: string) {
+    AppEventsLogger.setPushNotificationsRegistrationId(registrationId);
+  },
+
+  /**
    * Explicitly kicks off flushing of events to Facebook.
    */
   flush() {


### PR DESCRIPTION
Hi guys. Currently I am integrating [Facebook Push Campaigns](https://developers.facebook.com/docs/push-campaigns) in a react-native application.

What I faced as a problem is that the Analytics API in the **react-native-fbsdk** doesn't support setting push notifications registration id. ([setPushNotificationsRegistrationId(String)](https://developers.facebook.com/docs/reference/android/current/class/AppEventsLogger)).

I wanted to send a custom event and workaround it, but unfortunately it was not enough because of setting the **private static String pushNotificationsRegistrationId** variable inside the **setPushNotificationsRegistrationId()** function.

This pull request contains the support for this functionality. Unfortunately without it you cannot record the registration id in **Facebook Analytics**, which is a must for integrating **Facebook Push Campaigns**.
The solution is already tested and working. You can see the events recorded in **Facebook Analytics** below:

![facebook-push-notification-events-tracked](https://cloud.githubusercontent.com/assets/3698434/24402894/2c14fbb8-13c3-11e7-9604-c439a8a515bd.png)
 