### PR TITLE
react-native install is not a valid comment, changed to npm i -S

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ react-native init YourApp
 
 Install and link the react-native-fbsdk package:
 ```ruby
-react-native install react-native-fbsdk
+npm i -S react-native-fbsdk
 react-native link react-native-fbsdk
 ```
 ### 3. Configure native projects


### PR DESCRIPTION
When I run react-native install and then react-native link I receive this error:
`[Error: Cannot find module 'C:\wamp\www\chatapp\node_modules\react-native-fbsdk\package.json'] code: 'MODULE_NOT_FOUND'`

I realized that react-native is not a valid commend and with npm i it works!
Good luck,
Lior.