### PR TITLE
Update from View.propTypes to ViewPropTypes to match RNv0.44.0

### DIFF
--- a/js/FBLikeView.js
+++ b/js/FBLikeView.js
@@ -28,6 +28,7 @@ import {
   requireNativeComponent,
   StyleSheet,
   View,
+  ViewPropTypes
 } from 'react-native';
 
 import type { ObjectIdAndType } from './models/FBObjectIdAndType';
@@ -93,7 +94,7 @@ class LikeView extends React.Component {
 }
 
 LikeView.propTypes = {
-  ...View.propTypes,
+  ...ViewPropTypes,
   objectIdAndType: PropTypes.object.isRequired,
   likeViewStyle: PropTypes.oneOf(['standard', 'button', 'box_count']),
   auxiliaryViewPosition: PropTypes.oneOf(['top', 'bottom', 'inline']),

--- a/js/FBLoginButton.js
+++ b/js/FBLoginButton.js
@@ -28,6 +28,7 @@ import {
   requireNativeComponent,
   StyleSheet,
   View,
+  ViewPropTypes
 } from 'react-native';
 
 import type {
@@ -124,7 +125,7 @@ class LoginButton extends React.Component {
 }
 
 LoginButton.propTypes = {
-  ...View.propTypes,
+  ...ViewPropTypes,
   readPermissions: PropTypes.arrayOf(PropTypes.string),
   publishPermissions: PropTypes.arrayOf(PropTypes.string),
   onLoginFinished: PropTypes.func,

--- a/js/FBSendButton.js
+++ b/js/FBSendButton.js
@@ -28,6 +28,7 @@ import {
   requireNativeComponent,
   StyleSheet,
   View,
+  ViewPropTypes
 } from 'react-native';
 
 import type { ShareContent } from './models/FBShareContent';
@@ -59,7 +60,7 @@ class SendButton extends React.Component {
 }
 
 SendButton.propTypes = {
-  ...View.propTypes,
+  ...ViewPropTypes,
   shareContent: PropTypes.object,
 };
 

--- a/js/FBShareButton.js
+++ b/js/FBShareButton.js
@@ -29,6 +29,7 @@ import {
  requireNativeComponent,
  StyleSheet,
  View,
+ ViewPropTypes
 } from 'react-native';
 
 import type { ShareContent } from './models/FBShareContent';
@@ -60,7 +61,7 @@ class ShareButton extends React.Component {
 }
 
 ShareButton.propTypes = {
-  ...View.propTypes,
+  ...ViewPropTypes,
   shareContent: PropTypes.object,
 };
 


### PR DESCRIPTION
Update the ViewPropTypes to match the last revision of React Native V0.44.0

> Move View.propTypes to ViewPropTypes (53905a5) - @bvaughn 

https://github.com/facebook/react-native/releases