### PR TITLE
Android Build Tools and AppCompat update

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,28 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.2.3'
+    }
+}
+
+allprojects {
+    repositories {
+        jcenter()
+        maven { url "$projectDir/../node_modules/react-native/android" }
+    }
+}
+
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -21,7 +37,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.1.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.facebook.react:react-native:+' // support react-native-v0.22-rc+
     compile('com.facebook.android:facebook-android-sdk:4.+')
 }


### PR DESCRIPTION
AppCompat updated from 23.1.0 to 25.3.1
compileSdkVersion from 23 to 25
targetSdkVersion from 23 to 25
buildToolsVersion from 23.0.1 to 25.0.3
Added grade class path to build gradle support.