### PR TITLE
Fix width of button

### DIFF
--- a/js/FBLoginButton.js
+++ b/js/FBLoginButton.js
@@ -139,7 +139,7 @@ LoginButton.propTypes = {
 const styles = StyleSheet.create({
   defaultButtonStyle: {
     height: 30,
-    width: 180,
+    width: 190,
   },
 });
 


### PR DESCRIPTION

<img width="203" alt="fb-button" src="https://cloud.githubusercontent.com/assets/2737103/26169491/5e7a9a4a-3b2d-11e7-9582-890f9b849791.png">

The text `Continue with Facebook` in the button was being cut off because of the width of the button container. Increasing the width of the button fixed the issue

<img width="204" alt="fb" src="https://cloud.githubusercontent.com/assets/2737103/26169679/239f1ecc-3b2e-11e7-90a2-4e38c5fe7dcb.png">
