### PR TITLE
Adds native-only props to all views

### DIFF
--- a/js/FBLikeView.js
+++ b/js/FBLikeView.js
@@ -114,7 +114,18 @@ LikeView.defaultProps = { style: styles.defaultButtonStyle };
 
 const RCTFBLikeView = requireNativeComponent(
   'RCTFBLikeView',
-  LikeView
+  LikeView,
+  {
+    nativeOnly: {
+      onLayout: true,
+      testID: true,
+      importantForAccessibility: true,
+      accessibilityLiveRegion: true,
+      accessibilityComponentType: true,
+      accessibilityLabel: true,
+      renderToHardwareTextureAndroid: true,
+    }
+  }
 );
 
 module.exports = LikeView;

--- a/js/FBLoginButton.js
+++ b/js/FBLoginButton.js
@@ -150,7 +150,16 @@ LoginButton.defaultProps = {
 const RCTFBLoginButton = requireNativeComponent(
   'RCTFBLoginButton',
   LoginButton,
-  { nativeOnly: { onChange: true } }
+  { nativeOnly: {
+    onChange: true,
+    onLayout: true,
+    testID: true,
+    importantForAccessibility: true,
+    accessibilityLiveRegion: true,
+    accessibilityComponentType: true,
+    accessibilityLabel: true,
+    renderToHardwareTextureAndroid: true,
+  } }
 );
 
 module.exports = LoginButton;

--- a/js/FBSendButton.js
+++ b/js/FBSendButton.js
@@ -77,7 +77,17 @@ SendButton.defaultProps = {
 
 const RCTFBSendButton = requireNativeComponent(
   'RCTFBSendButton',
-  SendButton
+  SendButton,
+  { nativeOnly: {
+    onChange: true,
+    onLayout: true,
+    testID: true,
+    importantForAccessibility: true,
+    accessibilityLiveRegion: true,
+    accessibilityComponentType: true,
+    accessibilityLabel: true,
+    renderToHardwareTextureAndroid: true,
+  } }
 );
 
 module.exports = SendButton;

--- a/js/FBShareButton.js
+++ b/js/FBShareButton.js
@@ -78,7 +78,17 @@ ShareButton.defaultProps = {
 
 const RCTFBShareButton = requireNativeComponent(
   'RCTFBShareButton',
-  ShareButton
+  ShareButton,
+  { nativeOnly: {
+    onChange: true,
+    onLayout: true,
+    testID: true,
+    importantForAccessibility: true,
+    accessibilityLiveRegion: true,
+    accessibilityComponentType: true,
+    accessibilityLabel: true,
+    renderToHardwareTextureAndroid: true,
+  } }
 );
 
 module.exports = ShareButton;


### PR DESCRIPTION
There seems to be some issues with the new version of the native SDK (which is installed automatically by Gradle) and this package (for both versions 0.5 and 0.6). I don't like this fix, since every native view that I have programmed does not require this kind of setup. But it is the only solution I found in order to be able to continue developing my app.