### PR TITLE
Need for 0.5.0 version patch - use 4.22.1 version of facebook-android-sdk

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,5 +19,5 @@ android {
 dependencies {
     compile 'com.android.support:appcompat-v7:25.0.0'
     compile 'com.facebook.react:react-native:+' // support react-native-v0.22-rc+
-    compile('com.facebook.android:facebook-android-sdk:4.+')
+    compile('com.facebook.android:facebook-android-sdk:4.22.+')
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,5 +19,5 @@ android {
 dependencies {
     compile 'com.android.support:appcompat-v7:25.0.0'
     compile 'com.facebook.react:react-native:+' // support react-native-v0.22-rc+
-    compile('com.facebook.android:facebook-android-sdk:4.22.+')
+    compile('com.facebook.android:facebook-android-sdk:4.22.1')
 }


### PR DESCRIPTION
Hi,

Facebook Android SDK was updated yesterday (https://github.com/facebook/facebook-android-sdk/commit/d47ac9335772a05e9f6693674eb3cca4a85342bd) and due to this fact, we cannot longer use `facebook-android-sdk 4.+` version in android/build.gradle for `0.5.0` tag, since it results in regression.

The issue is as follows:
```
:react-native-fbsdk:processReleaseResources/[mydir]/src/
node_modules/react-native-fbsdk/android/build/intermediates/
res/merged/release/values-v24/values-v24.xml:3: 

AAPT: Error retrieving parent for item: 

No resource found that matches the given name 'android:TextAppearance.Material.Widget.Button.Borderless.Colored'.
```

Please release 0.5.1 version with fix applied. 😊 

