### PR TITLE
restore react-native link functionality

### DIFF
--- a/ios/ios.xcodeproj/project.pbxproj
+++ b/ios/ios.xcodeproj/project.pbxproj
@@ -1,1591 +1,535 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict>
-	</dict>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>1DD70E29C049749700000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RNSDK-Debug.xcconfig</string>
-			<key>path</key>
-			<string>../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDK-Debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.xcconfig</string>
-		</dict>
-		<key>1DD70E29B8E1424100000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RNSDK-Profile.xcconfig</string>
-			<key>path</key>
-			<string>../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDK-Profile.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.xcconfig</string>
-		</dict>
-		<key>1DD70E292C77EDA300000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RNSDK-Release.xcconfig</string>
-			<key>path</key>
-			<string>../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDK-Release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.xcconfig</string>
-		</dict>
-		<key>1DD70E29F349631C00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RNSDKCoreKit-Debug.xcconfig</string>
-			<key>path</key>
-			<string>../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKCoreKit-Debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.xcconfig</string>
-		</dict>
-		<key>1DD70E292B9FA38600000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RNSDKCoreKit-Profile.xcconfig</string>
-			<key>path</key>
-			<string>../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKCoreKit-Profile.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.xcconfig</string>
-		</dict>
-		<key>1DD70E299F364EE800000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RNSDKCoreKit-Release.xcconfig</string>
-			<key>path</key>
-			<string>../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKCoreKit-Release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.xcconfig</string>
-		</dict>
-		<key>1DD70E297A21682A00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RNSDKLoginKit-Debug.xcconfig</string>
-			<key>path</key>
-			<string>../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKLoginKit-Debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.xcconfig</string>
-		</dict>
-		<key>1DD70E295C8A9D1400000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RNSDKLoginKit-Profile.xcconfig</string>
-			<key>path</key>
-			<string>../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKLoginKit-Profile.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.xcconfig</string>
-		</dict>
-		<key>1DD70E29D021487600000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RNSDKLoginKit-Release.xcconfig</string>
-			<key>path</key>
-			<string>../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKLoginKit-Release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.xcconfig</string>
-		</dict>
-		<key>1DD70E2971F1D72000000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RNSDKShareKit-Debug.xcconfig</string>
-			<key>path</key>
-			<string>../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKShareKit-Debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.xcconfig</string>
-		</dict>
-		<key>1DD70E29A1FB268A00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RNSDKShareKit-Profile.xcconfig</string>
-			<key>path</key>
-			<string>../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKShareKit-Profile.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.xcconfig</string>
-		</dict>
-		<key>1DD70E291591D1EC00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RNSDKShareKit-Release.xcconfig</string>
-			<key>path</key>
-			<string>../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKShareKit-Release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.xcconfig</string>
-		</dict>
-		<key>B401C9792F7F325000000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Buck (Do Not Modify)</string>
-			<key>sourceTree</key>
-			<string><![CDATA[<group>]]></string>
-			<key>children</key>
-			<array>
-				<string>1DD70E29C049749700000000</string>
-				<string>1DD70E29B8E1424100000000</string>
-				<string>1DD70E292C77EDA300000000</string>
-				<string>1DD70E29F349631C00000000</string>
-				<string>1DD70E292B9FA38600000000</string>
-				<string>1DD70E299F364EE800000000</string>
-				<string>1DD70E297A21682A00000000</string>
-				<string>1DD70E295C8A9D1400000000</string>
-				<string>1DD70E29D021487600000000</string>
-				<string>1DD70E2971F1D72000000000</string>
-				<string>1DD70E29A1FB268A00000000</string>
-				<string>1DD70E291591D1EC00000000</string>
-			</array>
-		</dict>
-		<key>B401C979B781F65D00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Configurations</string>
-			<key>sourceTree</key>
-			<string><![CDATA[<group>]]></string>
-			<key>children</key>
-			<array>
-				<string>B401C9792F7F325000000000</string>
-			</array>
-		</dict>
-		<key>1DD70E291ECB10AC00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>libRNSDK.a</string>
-			<key>path</key>
-			<string>libRNSDK.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-		</dict>
-		<key>1DD70E29AC0CD5F100000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>libRNSDKCoreKit.a</string>
-			<key>path</key>
-			<string>libRNSDKCoreKit.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-		</dict>
-		<key>1DD70E29031DBF3900000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>libRNSDKLoginKit.a</string>
-			<key>path</key>
-			<string>libRNSDKLoginKit.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-		</dict>
-		<key>1DD70E2900B6388300000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>libRNSDKShareKit.a</string>
-			<key>path</key>
-			<string>libRNSDKShareKit.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-		</dict>
-		<key>B401C979C806358400000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string><![CDATA[<group>]]></string>
-			<key>children</key>
-			<array>
-				<string>1DD70E291ECB10AC00000000</string>
-				<string>1DD70E29AC0CD5F100000000</string>
-				<string>1DD70E29031DBF3900000000</string>
-				<string>1DD70E2900B6388300000000</string>
-			</array>
-		</dict>
-		<key>1DD70E29001F47FB00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>BUCK</string>
-			<key>path</key>
-			<string>BUCK</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.script.python</string>
-		</dict>
-		<key>B401C979EAB5339800000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Sources</string>
-			<key>sourceTree</key>
-			<string><![CDATA[<group>]]></string>
-			<key>children</key>
-			<array>
-			</array>
-		</dict>
-		<key>B401C97904A83C5E00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>RNSDK</string>
-			<key>sourceTree</key>
-			<string><![CDATA[<group>]]></string>
-			<key>children</key>
-			<array>
-				<string>1DD70E29001F47FB00000000</string>
-				<string>B401C979EAB5339800000000</string>
-			</array>
-		</dict>
-		<key>1DD70E29001F47FB00000001</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>BUCK</string>
-			<key>path</key>
-			<string>BUCK</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.script.python</string>
-		</dict>
-		<key>1DD70E29239FB7EC00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTConvert+FBSDKAccessToken.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/core/RCTConvert+FBSDKAccessToken.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E29239FB7F100000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTConvert+FBSDKAccessToken.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/core/RCTConvert+FBSDKAccessToken.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E29BECE3BF400000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKAccessToken.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/core/RCTFBSDKAccessToken.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E29BECE3BF900000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKAccessToken.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/core/RCTFBSDKAccessToken.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E291A45CB9900000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKAppEvents.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/core/RCTFBSDKAppEvents.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E291A45CB9E00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKAppEvents.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/core/RCTFBSDKAppEvents.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E29C57E516100000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKGraphRequestConnectionContainer.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/core/RCTFBSDKGraphRequestConnectionContainer.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E29C57E516600000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKGraphRequestConnectionContainer.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/core/RCTFBSDKGraphRequestConnectionContainer.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E2931E55D4B00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKGraphRequestManager.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/core/RCTFBSDKGraphRequestManager.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E2931E55D5000000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKGraphRequestManager.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/core/RCTFBSDKGraphRequestManager.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E2928DCC8A600000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKInitializer.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/core/RCTFBSDKInitializer.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>B401C979EAB5339800000001</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Sources</string>
-			<key>sourceTree</key>
-			<string><![CDATA[<group>]]></string>
-			<key>children</key>
-			<array>
-				<string>1DD70E29239FB7EC00000000</string>
-				<string>1DD70E29239FB7F100000000</string>
-				<string>1DD70E29BECE3BF400000000</string>
-				<string>1DD70E29BECE3BF900000000</string>
-				<string>1DD70E291A45CB9900000000</string>
-				<string>1DD70E291A45CB9E00000000</string>
-				<string>1DD70E29C57E516100000000</string>
-				<string>1DD70E29C57E516600000000</string>
-				<string>1DD70E2931E55D4B00000000</string>
-				<string>1DD70E2931E55D5000000000</string>
-				<string>1DD70E2928DCC8A600000000</string>
-			</array>
-		</dict>
-		<key>B401C97975ABB47900000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>RNSDKCoreKit</string>
-			<key>sourceTree</key>
-			<string><![CDATA[<group>]]></string>
-			<key>children</key>
-			<array>
-				<string>1DD70E29001F47FB00000001</string>
-				<string>B401C979EAB5339800000001</string>
-			</array>
-		</dict>
-		<key>1DD70E29001F47FB00000002</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>BUCK</string>
-			<key>path</key>
-			<string>BUCK</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.script.python</string>
-		</dict>
-		<key>1DD70E29F12CB92000000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTConvert+FBSDKLogin.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/login/RCTConvert+FBSDKLogin.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E29F12CB92500000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTConvert+FBSDKLogin.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/login/RCTConvert+FBSDKLogin.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E29373304C700000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKLoginButtonManager.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/login/RCTFBSDKLoginButtonManager.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E29373304CC00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKLoginButtonManager.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/login/RCTFBSDKLoginButtonManager.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E29A8F8915900000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKLoginManager.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/login/RCTFBSDKLoginManager.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E29A8F8915E00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKLoginManager.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/login/RCTFBSDKLoginManager.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>B401C979EAB5339800000002</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Sources</string>
-			<key>sourceTree</key>
-			<string><![CDATA[<group>]]></string>
-			<key>children</key>
-			<array>
-				<string>1DD70E29F12CB92000000000</string>
-				<string>1DD70E29F12CB92500000000</string>
-				<string>1DD70E29373304C700000000</string>
-				<string>1DD70E29373304CC00000000</string>
-				<string>1DD70E29A8F8915900000000</string>
-				<string>1DD70E29A8F8915E00000000</string>
-			</array>
-		</dict>
-		<key>B401C979D437F52B00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>RNSDKLoginKit</string>
-			<key>sourceTree</key>
-			<string><![CDATA[<group>]]></string>
-			<key>children</key>
-			<array>
-				<string>1DD70E29001F47FB00000002</string>
-				<string>B401C979EAB5339800000002</string>
-			</array>
-		</dict>
-		<key>1DD70E29001F47FB00000003</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>BUCK</string>
-			<key>path</key>
-			<string>BUCK</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>explicitFileType</key>
-			<string>text.script.python</string>
-		</dict>
-		<key>1DD70E298740595A00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTConvert+FBSDKSharingContent.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTConvert+FBSDKSharingContent.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E298740595F00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTConvert+FBSDKSharingContent.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTConvert+FBSDKSharingContent.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E2920FC65B100000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKAppInviteDialog.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKAppInviteDialog.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E2920FC65B600000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKAppInviteDialog.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKAppInviteDialog.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E2940AA372400000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKGameRequestDialog.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKGameRequestDialog.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E2940AA372900000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKGameRequestDialog.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKGameRequestDialog.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E29F7DF835C00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKLikeControlManager.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKLikeControlManager.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E29F7DF836100000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKLikeControlManager.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKLikeControlManager.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E299BAF8D6E00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKMessageDialog.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKMessageDialog.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E299BAF8D7300000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKMessageDialog.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKMessageDialog.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E29EBCCFB3200000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKSendButtonManager.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKSendButtonManager.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E29EBCCFB3700000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKSendButtonManager.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKSendButtonManager.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E29ED6CD2D000000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKShareAPI.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKShareAPI.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E29ED6CD2D500000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKShareAPI.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKShareAPI.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E293963E99100000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKShareButtonManager.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKShareButtonManager.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E293963E99600000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKShareButtonManager.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKShareButtonManager.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E29F96A828600000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKShareDialog.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKShareDialog.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E29F96A828B00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKShareDialog.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKShareDialog.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>1DD70E29D84F936C00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKShareHelper.h</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKShareHelper.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-		</dict>
-		<key>1DD70E29D84F937100000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RCTFBSDKShareHelper.m</string>
-			<key>path</key>
-			<string>RCTFBSDK/share/RCTFBSDKShareHelper.m</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-		</dict>
-		<key>B401C979EAB5339800000003</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Sources</string>
-			<key>sourceTree</key>
-			<string><![CDATA[<group>]]></string>
-			<key>children</key>
-			<array>
-				<string>1DD70E298740595A00000000</string>
-				<string>1DD70E298740595F00000000</string>
-				<string>1DD70E2920FC65B100000000</string>
-				<string>1DD70E2920FC65B600000000</string>
-				<string>1DD70E2940AA372400000000</string>
-				<string>1DD70E2940AA372900000000</string>
-				<string>1DD70E29F7DF835C00000000</string>
-				<string>1DD70E29F7DF836100000000</string>
-				<string>1DD70E299BAF8D6E00000000</string>
-				<string>1DD70E299BAF8D7300000000</string>
-				<string>1DD70E29EBCCFB3200000000</string>
-				<string>1DD70E29EBCCFB3700000000</string>
-				<string>1DD70E29ED6CD2D000000000</string>
-				<string>1DD70E29ED6CD2D500000000</string>
-				<string>1DD70E293963E99100000000</string>
-				<string>1DD70E293963E99600000000</string>
-				<string>1DD70E29F96A828600000000</string>
-				<string>1DD70E29F96A828B00000000</string>
-				<string>1DD70E29D84F936C00000000</string>
-				<string>1DD70E29D84F937100000000</string>
-			</array>
-		</dict>
-		<key>B401C9792F5238F500000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>RNSDKShareKit</string>
-			<key>sourceTree</key>
-			<string><![CDATA[<group>]]></string>
-			<key>children</key>
-			<array>
-				<string>1DD70E29001F47FB00000003</string>
-				<string>B401C979EAB5339800000003</string>
-			</array>
-		</dict>
-		<key>B401C979EFB6AC4600000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>mainGroup</string>
-			<key>sourceTree</key>
-			<string><![CDATA[<group>]]></string>
-			<key>children</key>
-			<array>
-				<string>B401C979B781F65D00000000</string>
-				<string>B401C979C806358400000000</string>
-				<string>B401C97904A83C5E00000000</string>
-				<string>B401C97975ABB47900000000</string>
-				<string>B401C979D437F52B00000000</string>
-				<string>B401C9792F5238F500000000</string>
-			</array>
-		</dict>
-		<key>4952437303EDA63300000000</key>
-		<dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-			<key>buildSettings</key>
-			<dict>
-			</dict>
-			<key>baseConfigurationReference</key>
-			<string>1DD70E29C049749700000000</string>
-		</dict>
-		<key>4952437350C7218900000000</key>
-		<dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-			<key>buildSettings</key>
-			<dict>
-			</dict>
-			<key>baseConfigurationReference</key>
-			<string>1DD70E29B8E1424100000000</string>
-		</dict>
-		<key>49524373A439BFE700000000</key>
-		<dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-			<key>buildSettings</key>
-			<dict>
-			</dict>
-			<key>baseConfigurationReference</key>
-			<string>1DD70E292C77EDA300000000</string>
-		</dict>
-		<key>218C37090000000000000000</key>
-		<dict>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-			<key>buildConfigurations</key>
-			<array>
-				<string>4952437303EDA63300000000</string>
-				<string>4952437350C7218900000000</string>
-				<string>49524373A439BFE700000000</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<false/>
-		</dict>
-		<key>E66DC04E04A83C5E00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>RNSDK</string>
-			<key>productName</key>
-			<string>RNSDK</string>
-			<key>productReference</key>
-			<string>1DD70E291ECB10AC00000000</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-			<key>dependencies</key>
-			<array>
-			</array>
-			<key>buildPhases</key>
-			<array>
-			</array>
-			<key>buildConfigurationList</key>
-			<string>218C37090000000000000000</string>
-		</dict>
-		<key>E7A30F04239FB7F100000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E29239FB7F100000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F04BECE3BF900000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E29BECE3BF900000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F041A45CB9E00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E291A45CB9E00000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F04C57E516600000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E29C57E516600000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F0431E55D5000000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E2931E55D5000000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F0428DCC8A600000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E2928DCC8A600000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>1870857F0000000000000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>files</key>
-			<array>
-				<string>E7A30F04239FB7F100000000</string>
-				<string>E7A30F04BECE3BF900000000</string>
-				<string>E7A30F041A45CB9E00000000</string>
-				<string>E7A30F04C57E516600000000</string>
-				<string>E7A30F0431E55D5000000000</string>
-				<string>E7A30F0428DCC8A600000000</string>
-			</array>
-		</dict>
-		<key>4952437303EDA63300000001</key>
-		<dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-			<key>buildSettings</key>
-			<dict>
-			</dict>
-			<key>baseConfigurationReference</key>
-			<string>1DD70E29F349631C00000000</string>
-		</dict>
-		<key>4952437350C7218900000001</key>
-		<dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-			<key>buildSettings</key>
-			<dict>
-			</dict>
-			<key>baseConfigurationReference</key>
-			<string>1DD70E292B9FA38600000000</string>
-		</dict>
-		<key>49524373A439BFE700000001</key>
-		<dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-			<key>buildSettings</key>
-			<dict>
-			</dict>
-			<key>baseConfigurationReference</key>
-			<string>1DD70E299F364EE800000000</string>
-		</dict>
-		<key>218C37090000000000000001</key>
-		<dict>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-			<key>buildConfigurations</key>
-			<array>
-				<string>4952437303EDA63300000001</string>
-				<string>4952437350C7218900000001</string>
-				<string>49524373A439BFE700000001</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<false/>
-		</dict>
-		<key>E66DC04E75ABB47900000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>RNSDKCoreKit</string>
-			<key>productName</key>
-			<string>RNSDKCoreKit</string>
-			<key>productReference</key>
-			<string>1DD70E29AC0CD5F100000000</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-			<key>dependencies</key>
-			<array>
-			</array>
-			<key>buildPhases</key>
-			<array>
-				<string>1870857F0000000000000000</string>
-			</array>
-			<key>buildConfigurationList</key>
-			<string>218C37090000000000000001</string>
-		</dict>
-		<key>E7A30F04F12CB92500000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E29F12CB92500000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F04373304CC00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E29373304CC00000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F04A8F8915E00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E29A8F8915E00000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>1870857F0000000000000001</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>files</key>
-			<array>
-				<string>E7A30F04F12CB92500000000</string>
-				<string>E7A30F04373304CC00000000</string>
-				<string>E7A30F04A8F8915E00000000</string>
-			</array>
-		</dict>
-		<key>4952437303EDA63300000002</key>
-		<dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-			<key>buildSettings</key>
-			<dict>
-			</dict>
-			<key>baseConfigurationReference</key>
-			<string>1DD70E297A21682A00000000</string>
-		</dict>
-		<key>4952437350C7218900000002</key>
-		<dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-			<key>buildSettings</key>
-			<dict>
-			</dict>
-			<key>baseConfigurationReference</key>
-			<string>1DD70E295C8A9D1400000000</string>
-		</dict>
-		<key>49524373A439BFE700000002</key>
-		<dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-			<key>buildSettings</key>
-			<dict>
-			</dict>
-			<key>baseConfigurationReference</key>
-			<string>1DD70E29D021487600000000</string>
-		</dict>
-		<key>218C37090000000000000002</key>
-		<dict>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-			<key>buildConfigurations</key>
-			<array>
-				<string>4952437303EDA63300000002</string>
-				<string>4952437350C7218900000002</string>
-				<string>49524373A439BFE700000002</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<false/>
-		</dict>
-		<key>E66DC04ED437F52B00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>RNSDKLoginKit</string>
-			<key>productName</key>
-			<string>RNSDKLoginKit</string>
-			<key>productReference</key>
-			<string>1DD70E29031DBF3900000000</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-			<key>dependencies</key>
-			<array>
-			</array>
-			<key>buildPhases</key>
-			<array>
-				<string>1870857F0000000000000001</string>
-			</array>
-			<key>buildConfigurationList</key>
-			<string>218C37090000000000000002</string>
-		</dict>
-		<key>E7A30F048740595F00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E298740595F00000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F0420FC65B600000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E2920FC65B600000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F0440AA372900000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E2940AA372900000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F04F7DF836100000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E29F7DF836100000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F049BAF8D7300000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E299BAF8D7300000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F04EBCCFB3700000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E29EBCCFB3700000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F04ED6CD2D500000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E29ED6CD2D500000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F043963E99600000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E293963E99600000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F04F96A828B00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E29F96A828B00000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>E7A30F04D84F937100000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>fileRef</key>
-			<string>1DD70E29D84F937100000000</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1</string>
-			</dict>
-		</dict>
-		<key>1870857F0000000000000002</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>files</key>
-			<array>
-				<string>E7A30F048740595F00000000</string>
-				<string>E7A30F0420FC65B600000000</string>
-				<string>E7A30F0440AA372900000000</string>
-				<string>E7A30F04F7DF836100000000</string>
-				<string>E7A30F049BAF8D7300000000</string>
-				<string>E7A30F04EBCCFB3700000000</string>
-				<string>E7A30F04ED6CD2D500000000</string>
-				<string>E7A30F043963E99600000000</string>
-				<string>E7A30F04F96A828B00000000</string>
-				<string>E7A30F04D84F937100000000</string>
-			</array>
-		</dict>
-		<key>4952437303EDA63300000003</key>
-		<dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-			<key>buildSettings</key>
-			<dict>
-			</dict>
-			<key>baseConfigurationReference</key>
-			<string>1DD70E2971F1D72000000000</string>
-		</dict>
-		<key>4952437350C7218900000003</key>
-		<dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-			<key>buildSettings</key>
-			<dict>
-			</dict>
-			<key>baseConfigurationReference</key>
-			<string>1DD70E29A1FB268A00000000</string>
-		</dict>
-		<key>49524373A439BFE700000003</key>
-		<dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-			<key>buildSettings</key>
-			<dict>
-			</dict>
-			<key>baseConfigurationReference</key>
-			<string>1DD70E291591D1EC00000000</string>
-		</dict>
-		<key>218C37090000000000000003</key>
-		<dict>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-			<key>buildConfigurations</key>
-			<array>
-				<string>4952437303EDA63300000003</string>
-				<string>4952437350C7218900000003</string>
-				<string>49524373A439BFE700000003</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<false/>
-		</dict>
-		<key>E66DC04E2F5238F500000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>RNSDKShareKit</string>
-			<key>productName</key>
-			<string>RNSDKShareKit</string>
-			<key>productReference</key>
-			<string>1DD70E2900B6388300000000</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-			<key>dependencies</key>
-			<array>
-			</array>
-			<key>buildPhases</key>
-			<array>
-				<string>1870857F0000000000000002</string>
-			</array>
-			<key>buildConfigurationList</key>
-			<string>218C37090000000000000003</string>
-		</dict>
-		<key>4952437303EDA63300000004</key>
-		<dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-			<key>buildSettings</key>
-			<dict>
-			</dict>
-		</dict>
-		<key>4952437350C7218900000004</key>
-		<dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-			<key>buildSettings</key>
-			<dict>
-			</dict>
-		</dict>
-		<key>49524373A439BFE700000004</key>
-		<dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-			<key>buildSettings</key>
-			<dict>
-			</dict>
-		</dict>
-		<key>218C37090000000000000004</key>
-		<dict>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-			<key>buildConfigurations</key>
-			<array>
-				<string>4952437303EDA63300000004</string>
-				<string>4952437350C7218900000004</string>
-				<string>49524373A439BFE700000004</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<false/>
-		</dict>
-		<key>96C847930001980D00000000</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>mainGroup</key>
-			<string>B401C979EFB6AC4600000000</string>
-			<key>targets</key>
-			<array>
-				<string>E66DC04E04A83C5E00000000</string>
-				<string>E66DC04E75ABB47900000000</string>
-				<string>E66DC04ED437F52B00000000</string>
-				<string>E66DC04E2F5238F500000000</string>
-			</array>
-			<key>buildConfigurationList</key>
-			<string>218C37090000000000000004</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>attributes</key>
-			<dict>
-				<key>LastUpgradeCheck</key>
-				<string>9999</string>
-			</dict>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>96C847930001980D00000000</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		E7A30F041A45CB9E00000000 /* RCTFBSDKAppEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E291A45CB9E00000000 /* RCTFBSDKAppEvents.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F0420FC65B600000000 /* RCTFBSDKAppInviteDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E2920FC65B600000000 /* RCTFBSDKAppInviteDialog.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F04239FB7F100000000 /* RCTConvert+FBSDKAccessToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E29239FB7F100000000 /* RCTConvert+FBSDKAccessToken.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F0428DCC8A600000000 /* RCTFBSDKInitializer.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E2928DCC8A600000000 /* RCTFBSDKInitializer.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F0431E55D5000000000 /* RCTFBSDKGraphRequestManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E2931E55D5000000000 /* RCTFBSDKGraphRequestManager.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F04373304CC00000000 /* RCTFBSDKLoginButtonManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E29373304CC00000000 /* RCTFBSDKLoginButtonManager.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F043963E99600000000 /* RCTFBSDKShareButtonManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E293963E99600000000 /* RCTFBSDKShareButtonManager.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F0440AA372900000000 /* RCTFBSDKGameRequestDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E2940AA372900000000 /* RCTFBSDKGameRequestDialog.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F048740595F00000000 /* RCTConvert+FBSDKSharingContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E298740595F00000000 /* RCTConvert+FBSDKSharingContent.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F049BAF8D7300000000 /* RCTFBSDKMessageDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E299BAF8D7300000000 /* RCTFBSDKMessageDialog.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F04A8F8915E00000000 /* RCTFBSDKLoginManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E29A8F8915E00000000 /* RCTFBSDKLoginManager.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F04BECE3BF900000000 /* RCTFBSDKAccessToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E29BECE3BF900000000 /* RCTFBSDKAccessToken.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F04C57E516600000000 /* RCTFBSDKGraphRequestConnectionContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E29C57E516600000000 /* RCTFBSDKGraphRequestConnectionContainer.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F04D84F937100000000 /* RCTFBSDKShareHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E29D84F937100000000 /* RCTFBSDKShareHelper.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F04EBCCFB3700000000 /* RCTFBSDKSendButtonManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E29EBCCFB3700000000 /* RCTFBSDKSendButtonManager.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F04ED6CD2D500000000 /* RCTFBSDKShareAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E29ED6CD2D500000000 /* RCTFBSDKShareAPI.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F04F12CB92500000000 /* RCTConvert+FBSDKLogin.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E29F12CB92500000000 /* RCTConvert+FBSDKLogin.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F04F7DF836100000000 /* RCTFBSDKLikeControlManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E29F7DF836100000000 /* RCTFBSDKLikeControlManager.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+		E7A30F04F96A828B00000000 /* RCTFBSDKShareDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD70E29F96A828B00000000 /* RCTFBSDKShareDialog.m */; settings = {COMPILER_FLAGS = "-stdlib=libc++ -D_LIBCPP_HAS_NO_STRONG_ENUMS=1"; }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		1DD70E29001F47FB00000000 /* BUCK */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUCK; sourceTree = SOURCE_ROOT; };
+		1DD70E29001F47FB00000001 /* BUCK */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUCK; sourceTree = SOURCE_ROOT; };
+		1DD70E29001F47FB00000002 /* BUCK */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUCK; sourceTree = SOURCE_ROOT; };
+		1DD70E29001F47FB00000003 /* BUCK */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUCK; sourceTree = SOURCE_ROOT; };
+		1DD70E2900B6388300000000 /* libRNSDKShareKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = libRNSDKShareKit.a; path = lib.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		1DD70E29031DBF3900000000 /* libRNSDKLoginKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = libRNSDKLoginKit.a; path = lib.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		1DD70E291591D1EC00000000 /* RNSDKShareKit-Release.xcconfig */ = {isa = PBXFileReference; explicitFileType = text.xcconfig; name = "RNSDKShareKit-Release.xcconfig"; path = "../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKShareKit-Release.xcconfig"; sourceTree = SOURCE_ROOT; };
+		1DD70E291A45CB9900000000 /* RCTFBSDKAppEvents.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKAppEvents.h; path = RCTFBSDK/core/RCTFBSDKAppEvents.h; sourceTree = SOURCE_ROOT; };
+		1DD70E291A45CB9E00000000 /* RCTFBSDKAppEvents.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKAppEvents.m; path = RCTFBSDK/core/RCTFBSDKAppEvents.m; sourceTree = SOURCE_ROOT; };
+		1DD70E291ECB10AC00000000 /* libRNSDK.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = libRNSDK.a; path = lib.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		1DD70E2920FC65B100000000 /* RCTFBSDKAppInviteDialog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKAppInviteDialog.h; path = RCTFBSDK/share/RCTFBSDKAppInviteDialog.h; sourceTree = SOURCE_ROOT; };
+		1DD70E2920FC65B600000000 /* RCTFBSDKAppInviteDialog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKAppInviteDialog.m; path = RCTFBSDK/share/RCTFBSDKAppInviteDialog.m; sourceTree = SOURCE_ROOT; };
+		1DD70E29239FB7EC00000000 /* RCTConvert+FBSDKAccessToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "RCTConvert+FBSDKAccessToken.h"; path = "RCTFBSDK/core/RCTConvert+FBSDKAccessToken.h"; sourceTree = SOURCE_ROOT; };
+		1DD70E29239FB7F100000000 /* RCTConvert+FBSDKAccessToken.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "RCTConvert+FBSDKAccessToken.m"; path = "RCTFBSDK/core/RCTConvert+FBSDKAccessToken.m"; sourceTree = SOURCE_ROOT; };
+		1DD70E2928DCC8A600000000 /* RCTFBSDKInitializer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKInitializer.m; path = RCTFBSDK/core/RCTFBSDKInitializer.m; sourceTree = SOURCE_ROOT; };
+		1DD70E292B9FA38600000000 /* RNSDKCoreKit-Profile.xcconfig */ = {isa = PBXFileReference; explicitFileType = text.xcconfig; name = "RNSDKCoreKit-Profile.xcconfig"; path = "../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKCoreKit-Profile.xcconfig"; sourceTree = SOURCE_ROOT; };
+		1DD70E292C77EDA300000000 /* RNSDK-Release.xcconfig */ = {isa = PBXFileReference; explicitFileType = text.xcconfig; name = "RNSDK-Release.xcconfig"; path = "../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDK-Release.xcconfig"; sourceTree = SOURCE_ROOT; };
+		1DD70E2931E55D4B00000000 /* RCTFBSDKGraphRequestManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKGraphRequestManager.h; path = RCTFBSDK/core/RCTFBSDKGraphRequestManager.h; sourceTree = SOURCE_ROOT; };
+		1DD70E2931E55D5000000000 /* RCTFBSDKGraphRequestManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKGraphRequestManager.m; path = RCTFBSDK/core/RCTFBSDKGraphRequestManager.m; sourceTree = SOURCE_ROOT; };
+		1DD70E29373304C700000000 /* RCTFBSDKLoginButtonManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKLoginButtonManager.h; path = RCTFBSDK/login/RCTFBSDKLoginButtonManager.h; sourceTree = SOURCE_ROOT; };
+		1DD70E29373304CC00000000 /* RCTFBSDKLoginButtonManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKLoginButtonManager.m; path = RCTFBSDK/login/RCTFBSDKLoginButtonManager.m; sourceTree = SOURCE_ROOT; };
+		1DD70E293963E99100000000 /* RCTFBSDKShareButtonManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKShareButtonManager.h; path = RCTFBSDK/share/RCTFBSDKShareButtonManager.h; sourceTree = SOURCE_ROOT; };
+		1DD70E293963E99600000000 /* RCTFBSDKShareButtonManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKShareButtonManager.m; path = RCTFBSDK/share/RCTFBSDKShareButtonManager.m; sourceTree = SOURCE_ROOT; };
+		1DD70E2940AA372400000000 /* RCTFBSDKGameRequestDialog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKGameRequestDialog.h; path = RCTFBSDK/share/RCTFBSDKGameRequestDialog.h; sourceTree = SOURCE_ROOT; };
+		1DD70E2940AA372900000000 /* RCTFBSDKGameRequestDialog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKGameRequestDialog.m; path = RCTFBSDK/share/RCTFBSDKGameRequestDialog.m; sourceTree = SOURCE_ROOT; };
+		1DD70E295C8A9D1400000000 /* RNSDKLoginKit-Profile.xcconfig */ = {isa = PBXFileReference; explicitFileType = text.xcconfig; name = "RNSDKLoginKit-Profile.xcconfig"; path = "../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKLoginKit-Profile.xcconfig"; sourceTree = SOURCE_ROOT; };
+		1DD70E2971F1D72000000000 /* RNSDKShareKit-Debug.xcconfig */ = {isa = PBXFileReference; explicitFileType = text.xcconfig; name = "RNSDKShareKit-Debug.xcconfig"; path = "../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKShareKit-Debug.xcconfig"; sourceTree = SOURCE_ROOT; };
+		1DD70E297A21682A00000000 /* RNSDKLoginKit-Debug.xcconfig */ = {isa = PBXFileReference; explicitFileType = text.xcconfig; name = "RNSDKLoginKit-Debug.xcconfig"; path = "../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKLoginKit-Debug.xcconfig"; sourceTree = SOURCE_ROOT; };
+		1DD70E298740595A00000000 /* RCTConvert+FBSDKSharingContent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "RCTConvert+FBSDKSharingContent.h"; path = "RCTFBSDK/share/RCTConvert+FBSDKSharingContent.h"; sourceTree = SOURCE_ROOT; };
+		1DD70E298740595F00000000 /* RCTConvert+FBSDKSharingContent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "RCTConvert+FBSDKSharingContent.m"; path = "RCTFBSDK/share/RCTConvert+FBSDKSharingContent.m"; sourceTree = SOURCE_ROOT; };
+		1DD70E299BAF8D6E00000000 /* RCTFBSDKMessageDialog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKMessageDialog.h; path = RCTFBSDK/share/RCTFBSDKMessageDialog.h; sourceTree = SOURCE_ROOT; };
+		1DD70E299BAF8D7300000000 /* RCTFBSDKMessageDialog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKMessageDialog.m; path = RCTFBSDK/share/RCTFBSDKMessageDialog.m; sourceTree = SOURCE_ROOT; };
+		1DD70E299F364EE800000000 /* RNSDKCoreKit-Release.xcconfig */ = {isa = PBXFileReference; explicitFileType = text.xcconfig; name = "RNSDKCoreKit-Release.xcconfig"; path = "../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKCoreKit-Release.xcconfig"; sourceTree = SOURCE_ROOT; };
+		1DD70E29A1FB268A00000000 /* RNSDKShareKit-Profile.xcconfig */ = {isa = PBXFileReference; explicitFileType = text.xcconfig; name = "RNSDKShareKit-Profile.xcconfig"; path = "../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKShareKit-Profile.xcconfig"; sourceTree = SOURCE_ROOT; };
+		1DD70E29A8F8915900000000 /* RCTFBSDKLoginManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKLoginManager.h; path = RCTFBSDK/login/RCTFBSDKLoginManager.h; sourceTree = SOURCE_ROOT; };
+		1DD70E29A8F8915E00000000 /* RCTFBSDKLoginManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKLoginManager.m; path = RCTFBSDK/login/RCTFBSDKLoginManager.m; sourceTree = SOURCE_ROOT; };
+		1DD70E29AC0CD5F100000000 /* libRNSDKCoreKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = libRNSDKCoreKit.a; path = lib.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		1DD70E29B8E1424100000000 /* RNSDK-Profile.xcconfig */ = {isa = PBXFileReference; explicitFileType = text.xcconfig; name = "RNSDK-Profile.xcconfig"; path = "../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDK-Profile.xcconfig"; sourceTree = SOURCE_ROOT; };
+		1DD70E29BECE3BF400000000 /* RCTFBSDKAccessToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKAccessToken.h; path = RCTFBSDK/core/RCTFBSDKAccessToken.h; sourceTree = SOURCE_ROOT; };
+		1DD70E29BECE3BF900000000 /* RCTFBSDKAccessToken.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKAccessToken.m; path = RCTFBSDK/core/RCTFBSDKAccessToken.m; sourceTree = SOURCE_ROOT; };
+		1DD70E29C049749700000000 /* RNSDK-Debug.xcconfig */ = {isa = PBXFileReference; explicitFileType = text.xcconfig; name = "RNSDK-Debug.xcconfig"; path = "../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDK-Debug.xcconfig"; sourceTree = SOURCE_ROOT; };
+		1DD70E29C57E516100000000 /* RCTFBSDKGraphRequestConnectionContainer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKGraphRequestConnectionContainer.h; path = RCTFBSDK/core/RCTFBSDKGraphRequestConnectionContainer.h; sourceTree = SOURCE_ROOT; };
+		1DD70E29C57E516600000000 /* RCTFBSDKGraphRequestConnectionContainer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKGraphRequestConnectionContainer.m; path = RCTFBSDK/core/RCTFBSDKGraphRequestConnectionContainer.m; sourceTree = SOURCE_ROOT; };
+		1DD70E29D021487600000000 /* RNSDKLoginKit-Release.xcconfig */ = {isa = PBXFileReference; explicitFileType = text.xcconfig; name = "RNSDKLoginKit-Release.xcconfig"; path = "../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKLoginKit-Release.xcconfig"; sourceTree = SOURCE_ROOT; };
+		1DD70E29D84F936C00000000 /* RCTFBSDKShareHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKShareHelper.h; path = RCTFBSDK/share/RCTFBSDKShareHelper.h; sourceTree = SOURCE_ROOT; };
+		1DD70E29D84F937100000000 /* RCTFBSDKShareHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKShareHelper.m; path = RCTFBSDK/share/RCTFBSDKShareHelper.m; sourceTree = SOURCE_ROOT; };
+		1DD70E29EBCCFB3200000000 /* RCTFBSDKSendButtonManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKSendButtonManager.h; path = RCTFBSDK/share/RCTFBSDKSendButtonManager.h; sourceTree = SOURCE_ROOT; };
+		1DD70E29EBCCFB3700000000 /* RCTFBSDKSendButtonManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKSendButtonManager.m; path = RCTFBSDK/share/RCTFBSDKSendButtonManager.m; sourceTree = SOURCE_ROOT; };
+		1DD70E29ED6CD2D000000000 /* RCTFBSDKShareAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKShareAPI.h; path = RCTFBSDK/share/RCTFBSDKShareAPI.h; sourceTree = SOURCE_ROOT; };
+		1DD70E29ED6CD2D500000000 /* RCTFBSDKShareAPI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKShareAPI.m; path = RCTFBSDK/share/RCTFBSDKShareAPI.m; sourceTree = SOURCE_ROOT; };
+		1DD70E29F12CB92000000000 /* RCTConvert+FBSDKLogin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "RCTConvert+FBSDKLogin.h"; path = "RCTFBSDK/login/RCTConvert+FBSDKLogin.h"; sourceTree = SOURCE_ROOT; };
+		1DD70E29F12CB92500000000 /* RCTConvert+FBSDKLogin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "RCTConvert+FBSDKLogin.m"; path = "RCTFBSDK/login/RCTConvert+FBSDKLogin.m"; sourceTree = SOURCE_ROOT; };
+		1DD70E29F349631C00000000 /* RNSDKCoreKit-Debug.xcconfig */ = {isa = PBXFileReference; explicitFileType = text.xcconfig; name = "RNSDKCoreKit-Debug.xcconfig"; path = "../../../../../buck-out/gen/Libraries/FBReactKit/js/react-native-fbsdk/ios/RNSDKCoreKit-Debug.xcconfig"; sourceTree = SOURCE_ROOT; };
+		1DD70E29F7DF835C00000000 /* RCTFBSDKLikeControlManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKLikeControlManager.h; path = RCTFBSDK/share/RCTFBSDKLikeControlManager.h; sourceTree = SOURCE_ROOT; };
+		1DD70E29F7DF836100000000 /* RCTFBSDKLikeControlManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKLikeControlManager.m; path = RCTFBSDK/share/RCTFBSDKLikeControlManager.m; sourceTree = SOURCE_ROOT; };
+		1DD70E29F96A828600000000 /* RCTFBSDKShareDialog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKShareDialog.h; path = RCTFBSDK/share/RCTFBSDKShareDialog.h; sourceTree = SOURCE_ROOT; };
+		1DD70E29F96A828B00000000 /* RCTFBSDKShareDialog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKShareDialog.m; path = RCTFBSDK/share/RCTFBSDKShareDialog.m; sourceTree = SOURCE_ROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		B401C97904A83C5E00000000 /* RNSDK */ = {
+			isa = PBXGroup;
+			children = (
+				1DD70E29001F47FB00000000 /* BUCK */,
+				B401C979EAB5339800000000 /* Sources */,
+			);
+			name = RNSDK;
+			sourceTree = "<group>";
+		};
+		B401C9792F5238F500000000 /* RNSDKShareKit */ = {
+			isa = PBXGroup;
+			children = (
+				1DD70E29001F47FB00000003 /* BUCK */,
+				B401C979EAB5339800000003 /* Sources */,
+			);
+			name = RNSDKShareKit;
+			sourceTree = "<group>";
+		};
+		B401C9792F7F325000000000 /* Buck (Do Not Modify) */ = {
+			isa = PBXGroup;
+			children = (
+				1DD70E29C049749700000000 /* RNSDK-Debug.xcconfig */,
+				1DD70E29B8E1424100000000 /* RNSDK-Profile.xcconfig */,
+				1DD70E292C77EDA300000000 /* RNSDK-Release.xcconfig */,
+				1DD70E29F349631C00000000 /* RNSDKCoreKit-Debug.xcconfig */,
+				1DD70E292B9FA38600000000 /* RNSDKCoreKit-Profile.xcconfig */,
+				1DD70E299F364EE800000000 /* RNSDKCoreKit-Release.xcconfig */,
+				1DD70E297A21682A00000000 /* RNSDKLoginKit-Debug.xcconfig */,
+				1DD70E295C8A9D1400000000 /* RNSDKLoginKit-Profile.xcconfig */,
+				1DD70E29D021487600000000 /* RNSDKLoginKit-Release.xcconfig */,
+				1DD70E2971F1D72000000000 /* RNSDKShareKit-Debug.xcconfig */,
+				1DD70E29A1FB268A00000000 /* RNSDKShareKit-Profile.xcconfig */,
+				1DD70E291591D1EC00000000 /* RNSDKShareKit-Release.xcconfig */,
+			);
+			name = "Buck (Do Not Modify)";
+			sourceTree = "<group>";
+		};
+		B401C97975ABB47900000000 /* RNSDKCoreKit */ = {
+			isa = PBXGroup;
+			children = (
+				1DD70E29001F47FB00000001 /* BUCK */,
+				B401C979EAB5339800000001 /* Sources */,
+			);
+			name = RNSDKCoreKit;
+			sourceTree = "<group>";
+		};
+		B401C979B781F65D00000000 /* Configurations */ = {
+			isa = PBXGroup;
+			children = (
+				B401C9792F7F325000000000 /* Buck (Do Not Modify) */,
+			);
+			name = Configurations;
+			sourceTree = "<group>";
+		};
+		B401C979C806358400000000 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1DD70E291ECB10AC00000000 /* libRNSDK.a */,
+				1DD70E29AC0CD5F100000000 /* libRNSDKCoreKit.a */,
+				1DD70E29031DBF3900000000 /* libRNSDKLoginKit.a */,
+				1DD70E2900B6388300000000 /* libRNSDKShareKit.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B401C979D437F52B00000000 /* RNSDKLoginKit */ = {
+			isa = PBXGroup;
+			children = (
+				1DD70E29001F47FB00000002 /* BUCK */,
+				B401C979EAB5339800000002 /* Sources */,
+			);
+			name = RNSDKLoginKit;
+			sourceTree = "<group>";
+		};
+		B401C979EAB5339800000000 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Sources;
+			sourceTree = "<group>";
+		};
+		B401C979EAB5339800000001 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				1DD70E29239FB7EC00000000 /* RCTConvert+FBSDKAccessToken.h */,
+				1DD70E29239FB7F100000000 /* RCTConvert+FBSDKAccessToken.m */,
+				1DD70E29BECE3BF400000000 /* RCTFBSDKAccessToken.h */,
+				1DD70E29BECE3BF900000000 /* RCTFBSDKAccessToken.m */,
+				1DD70E291A45CB9900000000 /* RCTFBSDKAppEvents.h */,
+				1DD70E291A45CB9E00000000 /* RCTFBSDKAppEvents.m */,
+				1DD70E29C57E516100000000 /* RCTFBSDKGraphRequestConnectionContainer.h */,
+				1DD70E29C57E516600000000 /* RCTFBSDKGraphRequestConnectionContainer.m */,
+				1DD70E2931E55D4B00000000 /* RCTFBSDKGraphRequestManager.h */,
+				1DD70E2931E55D5000000000 /* RCTFBSDKGraphRequestManager.m */,
+				1DD70E2928DCC8A600000000 /* RCTFBSDKInitializer.m */,
+			);
+			name = Sources;
+			sourceTree = "<group>";
+		};
+		B401C979EAB5339800000002 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				1DD70E29F12CB92000000000 /* RCTConvert+FBSDKLogin.h */,
+				1DD70E29F12CB92500000000 /* RCTConvert+FBSDKLogin.m */,
+				1DD70E29373304C700000000 /* RCTFBSDKLoginButtonManager.h */,
+				1DD70E29373304CC00000000 /* RCTFBSDKLoginButtonManager.m */,
+				1DD70E29A8F8915900000000 /* RCTFBSDKLoginManager.h */,
+				1DD70E29A8F8915E00000000 /* RCTFBSDKLoginManager.m */,
+			);
+			name = Sources;
+			sourceTree = "<group>";
+		};
+		B401C979EAB5339800000003 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				1DD70E298740595A00000000 /* RCTConvert+FBSDKSharingContent.h */,
+				1DD70E298740595F00000000 /* RCTConvert+FBSDKSharingContent.m */,
+				1DD70E2920FC65B100000000 /* RCTFBSDKAppInviteDialog.h */,
+				1DD70E2920FC65B600000000 /* RCTFBSDKAppInviteDialog.m */,
+				1DD70E2940AA372400000000 /* RCTFBSDKGameRequestDialog.h */,
+				1DD70E2940AA372900000000 /* RCTFBSDKGameRequestDialog.m */,
+				1DD70E29F7DF835C00000000 /* RCTFBSDKLikeControlManager.h */,
+				1DD70E29F7DF836100000000 /* RCTFBSDKLikeControlManager.m */,
+				1DD70E299BAF8D6E00000000 /* RCTFBSDKMessageDialog.h */,
+				1DD70E299BAF8D7300000000 /* RCTFBSDKMessageDialog.m */,
+				1DD70E29EBCCFB3200000000 /* RCTFBSDKSendButtonManager.h */,
+				1DD70E29EBCCFB3700000000 /* RCTFBSDKSendButtonManager.m */,
+				1DD70E29ED6CD2D000000000 /* RCTFBSDKShareAPI.h */,
+				1DD70E29ED6CD2D500000000 /* RCTFBSDKShareAPI.m */,
+				1DD70E293963E99100000000 /* RCTFBSDKShareButtonManager.h */,
+				1DD70E293963E99600000000 /* RCTFBSDKShareButtonManager.m */,
+				1DD70E29F96A828600000000 /* RCTFBSDKShareDialog.h */,
+				1DD70E29F96A828B00000000 /* RCTFBSDKShareDialog.m */,
+				1DD70E29D84F936C00000000 /* RCTFBSDKShareHelper.h */,
+				1DD70E29D84F937100000000 /* RCTFBSDKShareHelper.m */,
+			);
+			name = Sources;
+			sourceTree = "<group>";
+		};
+		B401C979EFB6AC4600000000 /* mainGroup */ = {
+			isa = PBXGroup;
+			children = (
+				B401C979B781F65D00000000 /* Configurations */,
+				B401C979C806358400000000 /* Products */,
+				B401C97904A83C5E00000000 /* RNSDK */,
+				B401C97975ABB47900000000 /* RNSDKCoreKit */,
+				B401C979D437F52B00000000 /* RNSDKLoginKit */,
+				B401C9792F5238F500000000 /* RNSDKShareKit */,
+			);
+			name = mainGroup;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E66DC04E04A83C5E00000000 /* RNSDK */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 218C37090000000000000000 /* Build configuration list for PBXNativeTarget "RNSDK" */;
+			buildPhases = (
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RNSDK;
+			productName = RNSDK;
+			productReference = 1DD70E291ECB10AC00000000 /* libRNSDK.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		E66DC04E2F5238F500000000 /* RNSDKShareKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 218C37090000000000000003 /* Build configuration list for PBXNativeTarget "RNSDKShareKit" */;
+			buildPhases = (
+				1870857F0000000000000002 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RNSDKShareKit;
+			productName = RNSDKShareKit;
+			productReference = 1DD70E2900B6388300000000 /* libRNSDKShareKit.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		E66DC04E75ABB47900000000 /* RNSDKCoreKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 218C37090000000000000001 /* Build configuration list for PBXNativeTarget "RNSDKCoreKit" */;
+			buildPhases = (
+				1870857F0000000000000000 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RNSDKCoreKit;
+			productName = RNSDKCoreKit;
+			productReference = 1DD70E29AC0CD5F100000000 /* libRNSDKCoreKit.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		E66DC04ED437F52B00000000 /* RNSDKLoginKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 218C37090000000000000002 /* Build configuration list for PBXNativeTarget "RNSDKLoginKit" */;
+			buildPhases = (
+				1870857F0000000000000001 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RNSDKLoginKit;
+			productName = RNSDKLoginKit;
+			productReference = 1DD70E29031DBF3900000000 /* libRNSDKLoginKit.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		96C847930001980D00000000 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 9999;
+			};
+			buildConfigurationList = 218C37090000000000000004 /* Build configuration list for PBXProject "ios" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = B401C979EFB6AC4600000000 /* mainGroup */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E66DC04E04A83C5E00000000 /* RNSDK */,
+				E66DC04E75ABB47900000000 /* RNSDKCoreKit */,
+				E66DC04ED437F52B00000000 /* RNSDKLoginKit */,
+				E66DC04E2F5238F500000000 /* RNSDKShareKit */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1870857F0000000000000000 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				E7A30F04239FB7F100000000 /* RCTConvert+FBSDKAccessToken.m in Sources */,
+				E7A30F04BECE3BF900000000 /* RCTFBSDKAccessToken.m in Sources */,
+				E7A30F041A45CB9E00000000 /* RCTFBSDKAppEvents.m in Sources */,
+				E7A30F04C57E516600000000 /* RCTFBSDKGraphRequestConnectionContainer.m in Sources */,
+				E7A30F0431E55D5000000000 /* RCTFBSDKGraphRequestManager.m in Sources */,
+				E7A30F0428DCC8A600000000 /* RCTFBSDKInitializer.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1870857F0000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				E7A30F04F12CB92500000000 /* RCTConvert+FBSDKLogin.m in Sources */,
+				E7A30F04373304CC00000000 /* RCTFBSDKLoginButtonManager.m in Sources */,
+				E7A30F04A8F8915E00000000 /* RCTFBSDKLoginManager.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1870857F0000000000000002 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				E7A30F048740595F00000000 /* RCTConvert+FBSDKSharingContent.m in Sources */,
+				E7A30F0420FC65B600000000 /* RCTFBSDKAppInviteDialog.m in Sources */,
+				E7A30F0440AA372900000000 /* RCTFBSDKGameRequestDialog.m in Sources */,
+				E7A30F04F7DF836100000000 /* RCTFBSDKLikeControlManager.m in Sources */,
+				E7A30F049BAF8D7300000000 /* RCTFBSDKMessageDialog.m in Sources */,
+				E7A30F04EBCCFB3700000000 /* RCTFBSDKSendButtonManager.m in Sources */,
+				E7A30F04ED6CD2D500000000 /* RCTFBSDKShareAPI.m in Sources */,
+				E7A30F043963E99600000000 /* RCTFBSDKShareButtonManager.m in Sources */,
+				E7A30F04F96A828B00000000 /* RCTFBSDKShareDialog.m in Sources */,
+				E7A30F04D84F937100000000 /* RCTFBSDKShareHelper.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		4952437303EDA63300000000 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DD70E29C049749700000000 /* RNSDK-Debug.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		4952437303EDA63300000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DD70E29F349631C00000000 /* RNSDKCoreKit-Debug.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		4952437303EDA63300000002 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DD70E297A21682A00000000 /* RNSDKLoginKit-Debug.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		4952437303EDA63300000003 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DD70E2971F1D72000000000 /* RNSDKShareKit-Debug.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		4952437303EDA63300000004 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		4952437350C7218900000000 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DD70E29B8E1424100000000 /* RNSDK-Profile.xcconfig */;
+			buildSettings = {
+			};
+			name = Profile;
+		};
+		4952437350C7218900000001 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DD70E292B9FA38600000000 /* RNSDKCoreKit-Profile.xcconfig */;
+			buildSettings = {
+			};
+			name = Profile;
+		};
+		4952437350C7218900000002 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DD70E295C8A9D1400000000 /* RNSDKLoginKit-Profile.xcconfig */;
+			buildSettings = {
+			};
+			name = Profile;
+		};
+		4952437350C7218900000003 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DD70E29A1FB268A00000000 /* RNSDKShareKit-Profile.xcconfig */;
+			buildSettings = {
+			};
+			name = Profile;
+		};
+		4952437350C7218900000004 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Profile;
+		};
+		49524373A439BFE700000000 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DD70E292C77EDA300000000 /* RNSDK-Release.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		49524373A439BFE700000001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DD70E299F364EE800000000 /* RNSDKCoreKit-Release.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		49524373A439BFE700000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DD70E29D021487600000000 /* RNSDKLoginKit-Release.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		49524373A439BFE700000003 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DD70E291591D1EC00000000 /* RNSDKShareKit-Release.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		49524373A439BFE700000004 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		218C37090000000000000000 /* Build configuration list for PBXNativeTarget "RNSDK" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4952437303EDA63300000000 /* Debug */,
+				4952437350C7218900000000 /* Profile */,
+				49524373A439BFE700000000 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		218C37090000000000000001 /* Build configuration list for PBXNativeTarget "RNSDKCoreKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4952437303EDA63300000001 /* Debug */,
+				4952437350C7218900000001 /* Profile */,
+				49524373A439BFE700000001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		218C37090000000000000002 /* Build configuration list for PBXNativeTarget "RNSDKLoginKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4952437303EDA63300000002 /* Debug */,
+				4952437350C7218900000002 /* Profile */,
+				49524373A439BFE700000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		218C37090000000000000003 /* Build configuration list for PBXNativeTarget "RNSDKShareKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4952437303EDA63300000003 /* Debug */,
+				4952437350C7218900000003 /* Profile */,
+				49524373A439BFE700000003 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		218C37090000000000000004 /* Build configuration list for PBXProject "ios" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4952437303EDA63300000004 /* Debug */,
+				4952437350C7218900000004 /* Profile */,
+				49524373A439BFE700000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 96C847930001980D00000000 /* Project object */;
+}


### PR DESCRIPTION
react-native link doesn't support the new xml format yet, so for now we save it in the old format