### PR TITLE
add cocoapods install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ public class MainActivity extends ReactActivity {
 Before you can run the project, follow the [Getting Started Guide](https://developers.facebook.com/docs/android/getting-started/) for Facebook Android SDK to set up a Facebook app. You can skip the build.gradle changes since that's taken care of by the rnpm link step above, and the step of calling `FacebookSdk.sdkInitialize`. But **make sure** you follow the rest of the steps such as updating `strings.xml` and `AndroidManifest.xml`.
 
 #### 3.2 iOS project
+
+##### With CocoaPods
+Add the following line to your **Podfile**
+```ruby
+pod 'react-native-fbsdk', :path => '../node_modules/react-native-fbsdk/ios'
+```
+Then follow the instructions in the [Getting Started Guide](https://developers.facebook.com/docs/ios/getting-started/) for Facebook SDK for iOS and you're done.
+
+##### With rnpm
 The react-native-fbsdk has been linked by rnpm, the next step will be downloading and linking the native Facebook SDK for iOS.
 Make sure you have the latest [Xcode](https://developer.apple.com/xcode/) installed. Open the .xcodeproj in Xcode found in the `ios` subfolder from your project's root directory. Now, follow ***all the steps*** in the [Getting Started Guide](https://developers.facebook.com/docs/ios/getting-started/) for Facebook SDK for iOS. Along with `FBSDKCoreKit.framework`, don't forget to import `FBSDKShareKit.framework` and `FBSDKLoginKit.framework` into your Xcode project.
 


### PR DESCRIPTION
For projects that use cocoapods, rnpm tends to break things. I have tried installing the project using cocoapods by referencing the ios podspec, then following the getting started instructions and it worked.