### PR TITLE
add createJSModules for backward compatibility

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
@@ -67,4 +67,9 @@ public class FBSDKPackage implements ReactPackage {
                 new FBShareButtonManager()
         );
     }
+
+    // Deprecated in RN 0.47.0
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
 }


### PR DESCRIPTION
#345 removed the method completely. This PR is to provide backward compatibility for older react native versions.

I'm not too bothered which approach we use, remove it or keep for compatibility. Could we have a release soon to allow us to use React Native 0.47? 