### PR TITLE
Defer initialization of components until first usage  

### DIFF
--- a/ios/RCTFBSDK/login/RCTFBSDKLoginManager.m
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginManager.m
@@ -38,10 +38,9 @@ RCT_EXPORT_MODULE(FBLoginManager);
 
 - (FBSDKLoginManager *)loginManager
 {
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
+  if (_loginManager == nil) {
     _loginManager = [[FBSDKLoginManager alloc] init];
-  });
+  }
   return _loginManager;
 }
 

--- a/ios/RCTFBSDK/login/RCTFBSDKLoginManager.m
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginManager.m
@@ -36,12 +36,13 @@ RCT_EXPORT_MODULE(FBLoginManager);
   return dispatch_get_main_queue();
 }
 
-- (instancetype)init
+- (FBSDKLoginManager *)loginManager
 {
-  if ((self = [super init])) {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
     _loginManager = [[FBSDKLoginManager alloc] init];
-  }
-  return self;
+  });
+  return _loginManager;
 }
 
 + (BOOL)requiresMainQueueSetup
@@ -53,22 +54,22 @@ RCT_EXPORT_MODULE(FBLoginManager);
 
 RCT_EXPORT_METHOD(setLoginBehavior:(FBSDKLoginBehavior)behavior)
 {
-  _loginManager.loginBehavior = behavior;
+  [self loginManager].loginBehavior = behavior;
 }
 
 RCT_EXPORT_METHOD(setDefaultAudience:(FBSDKDefaultAudience)audience)
 {
-  _loginManager.defaultAudience = audience;
+  [self loginManager].defaultAudience = audience;
 }
 
 RCT_REMAP_METHOD(getLoginBehavior, getLoginBehavior_resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-  resolve(LoginBehaviorToString([_loginManager loginBehavior]));
+  resolve(LoginBehaviorToString([[self loginManager] loginBehavior]));
 }
 
 RCT_REMAP_METHOD(getDefaultAudience, getDefaultAudience_resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-  resolve(DefaultAudienceToString([_loginManager defaultAudience]));
+  resolve(DefaultAudienceToString([[self loginManager] defaultAudience]));
 }
 
 RCT_EXPORT_METHOD(logInWithReadPermissions:(NSStringArray *)permissions
@@ -87,7 +88,7 @@ RCT_EXPORT_METHOD(logInWithPublishPermissions:(NSStringArray *)permissions
 
 RCT_EXPORT_METHOD(logOut)
 {
-  [_loginManager logOut];
+  [[self loginManager] logOut];
 };
 
 #pragma mark - Helper Methods
@@ -107,9 +108,9 @@ RCT_EXPORT_METHOD(logOut)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if (isRead) {
-    [_loginManager logInWithReadPermissions:permissions handler:requestHandler];
+    [[self loginManager] logInWithReadPermissions:permissions handler:requestHandler];
   } else {
-    [_loginManager logInWithPublishPermissions:permissions handler:requestHandler];
+    [[self loginManager] logInWithPublishPermissions:permissions handler:requestHandler];
   }
 #pragma clang diagnostic pop
 }

--- a/ios/RCTFBSDK/login/RCTFBSDKLoginManager.m
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginManager.m
@@ -46,7 +46,7 @@ RCT_EXPORT_MODULE(FBLoginManager);
 
 + (BOOL)requiresMainQueueSetup
 {
-  return YES;
+  return NO;
 }
 
 #pragma mark - React Native Methods

--- a/ios/RCTFBSDK/share/RCTFBSDKAppInviteDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKAppInviteDialog.m
@@ -57,11 +57,10 @@ RCT_EXPORT_MODULE(FBAppInviteDialog);
 
 - (FBSDKAppInviteDialog *)dialog
 {
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
+  if (_dialog == nil) {
     _dialog = [[FBSDKAppInviteDialog alloc] init];
     _dialog.delegate = self;
-  });
+  }
   return _dialog;
 }
 

--- a/ios/RCTFBSDK/share/RCTFBSDKAppInviteDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKAppInviteDialog.m
@@ -55,13 +55,14 @@ RCT_EXPORT_MODULE(FBAppInviteDialog);
 
 #pragma mark - Object Lifecycle
 
-- (instancetype)init
+- (FBSDKAppInviteDialog *)dialog
 {
-  if ((self = [super init])) {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
     _dialog = [[FBSDKAppInviteDialog alloc] init];
     _dialog.delegate = self;
-  }
-  return self;
+  });
+  return _dialog;
 }
 
 + (BOOL)requiresMainQueueSetup
@@ -73,7 +74,7 @@ RCT_EXPORT_MODULE(FBAppInviteDialog);
 
 RCT_EXPORT_METHOD(canShow:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-  resolve(@([_dialog canShow]));
+  resolve(@([[self dialog] canShow]));
 }
 
 RCT_EXPORT_METHOD(show:(FBSDKAppInviteContent *)content
@@ -82,8 +83,8 @@ RCT_EXPORT_METHOD(show:(FBSDKAppInviteContent *)content
 {
   _showResolver = resolve;
   _showRejecter = reject;
-  [_dialog setContent:content];
-  [_dialog show];
+  [[self dialog] setContent:content];
+  [[self dialog] show];
 
 }
 

--- a/ios/RCTFBSDK/share/RCTFBSDKAppInviteDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKAppInviteDialog.m
@@ -66,7 +66,7 @@ RCT_EXPORT_MODULE(FBAppInviteDialog);
 
 + (BOOL)requiresMainQueueSetup
 {
-  return YES;
+  return NO;
 }
 
 #pragma mark - React Native Methods

--- a/ios/RCTFBSDK/share/RCTFBSDKGameRequestDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKGameRequestDialog.m
@@ -72,11 +72,10 @@ RCT_EXPORT_MODULE(FBGameRequestDialog);
 
 - (FBSDKGameRequestDialog *)dialog
 {
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
+  if (_dialog == nil) {
     _dialog = [[FBSDKGameRequestDialog alloc] init];
     _dialog.delegate = self;
-  });
+  }
   return _dialog;
 }
 

--- a/ios/RCTFBSDK/share/RCTFBSDKGameRequestDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKGameRequestDialog.m
@@ -81,7 +81,7 @@ RCT_EXPORT_MODULE(FBGameRequestDialog);
 
 + (BOOL)requiresMainQueueSetup
 {
-  return YES;
+  return NO;
 }
 
 #pragma mark - React Native Methods

--- a/ios/RCTFBSDK/share/RCTFBSDKGameRequestDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKGameRequestDialog.m
@@ -70,13 +70,14 @@ RCT_EXPORT_MODULE(FBGameRequestDialog);
 
 #pragma mark - Object Lifecycle
 
-- (instancetype)init
+- (FBSDKGameRequestDialog *)dialog
 {
-  if ((self = [super init])) {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
     _dialog = [[FBSDKGameRequestDialog alloc] init];
     _dialog.delegate = self;
-  }
-  return self;
+  });
+  return _dialog;
 }
 
 + (BOOL)requiresMainQueueSetup
@@ -88,7 +89,7 @@ RCT_EXPORT_MODULE(FBGameRequestDialog);
 
 RCT_EXPORT_METHOD(canShow:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-  resolve([NSNumber numberWithBool:[_dialog canShow]]);
+  resolve([NSNumber numberWithBool:[[self dialog] canShow]]);
 }
 
 RCT_EXPORT_METHOD(show:(FBSDKGameRequestContent *)gameRequestContent
@@ -97,8 +98,8 @@ RCT_EXPORT_METHOD(show:(FBSDKGameRequestContent *)gameRequestContent
 {
   _showResolve = resolve;
   _showReject = reject;
-  [_dialog setContent:gameRequestContent];
-  [_dialog show];
+  [[self dialog] setContent:gameRequestContent];
+  [[self dialog] show];
 }
 
 #pragma mark - FBSDKSharingDelegate

--- a/ios/RCTFBSDK/share/RCTFBSDKMessageDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKMessageDialog.m
@@ -43,11 +43,10 @@ RCT_EXPORT_MODULE(FBMessageDialog);
 
 - (FBSDKMessageDialog *)dialog
 {
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
+  if (_dialog == nil) {
     _dialog = [[FBSDKMessageDialog alloc] init];
     _dialog.delegate = self;
-  });
+  }
   return _dialog;
 }
 

--- a/ios/RCTFBSDK/share/RCTFBSDKMessageDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKMessageDialog.m
@@ -41,13 +41,14 @@ RCT_EXPORT_MODULE(FBMessageDialog);
 
 #pragma mark - Object Lifecycle
 
-- (instancetype)init
+- (FBSDKMessageDialog *)dialog
 {
-  if ((self = [super init])) {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
     _dialog = [[FBSDKMessageDialog alloc] init];
     _dialog.delegate = self;
-  }
-  return self;
+  });
+  return _dialog;
 }
 
 + (BOOL)requiresMainQueueSetup
@@ -59,10 +60,10 @@ RCT_EXPORT_MODULE(FBMessageDialog);
 
 RCT_EXPORT_METHOD(canShow:(RCTFBSDKSharingContent)content resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-  _dialog.shareContent = content;
-  if ([_dialog canShow]) {
+  [self dialog].shareContent = content;
+  if ([[self dialog] canShow]) {
     NSError *error;
-    if ([_dialog validateWithError:&error]) {
+    if ([[self dialog] validateWithError:&error]) {
       resolve(@YES);
     } else {
       reject(@"FacebookSDK", @"SharingContent is invalid", error);
@@ -76,13 +77,13 @@ RCT_EXPORT_METHOD(show:(RCTFBSDKSharingContent)content resolver:(RCTPromiseResol
 {
   _showResolve = resolve;
   _showReject = reject;
-  _dialog.shareContent = content;
-  [_dialog show];
+  [self dialog].shareContent = content;
+  [[self dialog] show];
 }
 
 RCT_EXPORT_METHOD(setShouldFailOnDataError:(BOOL)shouldFailOnDataError)
 {
-  _dialog.shouldFailOnDataError = shouldFailOnDataError;
+  [self dialog].shouldFailOnDataError = shouldFailOnDataError;
 }
 
 #pragma mark - FBSDKSharingDelegate

--- a/ios/RCTFBSDK/share/RCTFBSDKMessageDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKMessageDialog.m
@@ -52,7 +52,7 @@ RCT_EXPORT_MODULE(FBMessageDialog);
 
 + (BOOL)requiresMainQueueSetup
 {
-  return YES;
+  return NO;
 }
 
 #pragma mark - React Native Methods

--- a/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
@@ -45,11 +45,10 @@ RCT_EXPORT_MODULE(FBShareDialog);
 
 - (FBSDKShareDialog *)shareDialog
 {
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
+  if (_shareDialog == nil) {
     _shareDialog = [[FBSDKShareDialog alloc] init];
     _shareDialog.delegate = self;
-  });
+  }
   return _shareDialog;
 }
 

--- a/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
@@ -43,13 +43,14 @@ RCT_EXPORT_MODULE(FBShareDialog);
 
 #pragma mark - Object Lifecycle
 
-- (instancetype)init
+- (FBSDKShareDialog *)shareDialog
 {
-  if (self = [super init]) {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
     _shareDialog = [[FBSDKShareDialog alloc] init];
     _shareDialog.delegate = self;
-  }
-  return self;
+  });
+  return _shareDialog;
 }
 
 + (BOOL)requiresMainQueueSetup
@@ -61,10 +62,10 @@ RCT_EXPORT_MODULE(FBShareDialog);
 
 RCT_EXPORT_METHOD(canShow:(RCTFBSDKSharingContent)content resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-  _shareDialog.shareContent = content;
-  if ([_shareDialog canShow]) {
+  [self shareDialog].shareContent = content;
+  if ([[self shareDialog] canShow]) {
     NSError *error;
-    if ([_shareDialog validateWithError:&error]) {
+    if ([[self shareDialog] validateWithError:&error]) {
       resolve(@YES);
     } else {
       reject(@"FacebookSDK", @"SharingContent is invalid", error);
@@ -80,9 +81,9 @@ RCT_EXPORT_METHOD(show:(RCTFBSDKSharingContent)content
 {
   _showResolve = resolve;
   _showReject = reject;
-  _shareDialog.shareContent = content;
+  [self shareDialog].shareContent = content;
   dispatch_async(dispatch_get_main_queue(), ^{
-    if (!_shareDialog.fromViewController) {
+    if (![self shareDialog].fromViewController) {
       UIViewController *viewController = [UIApplication sharedApplication].delegate.window.rootViewController;
 
       // get the view controller closest to the foreground
@@ -90,20 +91,20 @@ RCT_EXPORT_METHOD(show:(RCTFBSDKSharingContent)content
         viewController = viewController.presentedViewController;
       }
 
-      _shareDialog.fromViewController = viewController;
+      [self shareDialog].fromViewController = viewController;
     }
-    [_shareDialog show];
+    [[self shareDialog] show];
   });
 }
 
 RCT_EXPORT_METHOD(setMode:(FBSDKShareDialogMode)mode)
 {
-  _shareDialog.mode = mode;
+  [self shareDialog].mode = mode;
 }
 
 RCT_EXPORT_METHOD(setShouldFailOnDataError:(BOOL)shouldFailOnDataError)
 {
-  _shareDialog.shouldFailOnDataError = shouldFailOnDataError;
+  [self shareDialog].shouldFailOnDataError = shouldFailOnDataError;
 }
 
 #pragma mark - FBSDKSharingDelegate

--- a/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
@@ -63,16 +63,18 @@ RCT_EXPORT_MODULE(FBShareDialog);
 RCT_EXPORT_METHOD(canShow:(RCTFBSDKSharingContent)content resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   [self shareDialog].shareContent = content;
-  if ([[self shareDialog] canShow]) {
-    NSError *error;
-    if ([[self shareDialog] validateWithError:&error]) {
-      resolve(@YES);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if ([[self shareDialog] canShow]) {
+      NSError *error;
+      if ([[self shareDialog] validateWithError:&error]) {
+        resolve(@YES);
+      } else {
+        reject(@"FacebookSDK", @"SharingContent is invalid", error);
+      }
     } else {
-      reject(@"FacebookSDK", @"SharingContent is invalid", error);
+      resolve(@NO);
     }
-  } else {
-    resolve(@NO);
-  }
+  });
 }
 
 RCT_EXPORT_METHOD(show:(RCTFBSDKSharingContent)content

--- a/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
@@ -54,7 +54,7 @@ RCT_EXPORT_MODULE(FBShareDialog);
 
 + (BOOL)requiresMainQueueSetup
 {
-  return YES;
+  return NO;
 }
 
 #pragma mark - React Native Methods


### PR DESCRIPTION
all these modules are initialized on app startup, which not only adds time to the startup, but all also cause network requests to happen.

Because of legal reasons we're not allowed to have any potential privacy sensitive request to be made before given consent, and having these initializations deferred until first usage makes us pass this requirement.

Nb. I now only placed certain UI method calls in a `dispatch_async` block, but probably all of them should be done like that.