### PR TITLE
fixed header search path for use with CxxBridge

### DIFF
--- a/ios/RCTFBSDK.xcodeproj/project.pbxproj
+++ b/ios/RCTFBSDK.xcodeproj/project.pbxproj
@@ -371,7 +371,9 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"${SRCROOT}/../../../ios/**",
+					"${SRCROOT}/../../../ios/Pods/FBSDKCoreKit/FBSDKCoreKit",
+					"${SRCROOT}/../../../ios/Pods/FBSDKLoginKit/FBSDKLoginKit",
+					"${SRCROOT}/../../../ios/Pods/FBSDKShareKit/FBSDKShareKit",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -393,7 +395,9 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"${SRCROOT}/../../../ios/**",
+					"${SRCROOT}/../../../ios/Pods/FBSDKCoreKit/FBSDKCoreKit",
+					"${SRCROOT}/../../../ios/Pods/FBSDKLoginKit/FBSDKLoginKit",
+					"${SRCROOT}/../../../ios/Pods/FBSDKShareKit/FBSDKShareKit",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
This pull request fixes the issue discussed here https://developers.facebook.com/bugs/111079162900447

When using react-native > 0.47 in combination with CxxBridge this project doesn't build and fails with the error 'limits' file not found.

Xiao Liang from the Facebook team proposed to open this PR here so it would be nice if you can merge it.