### PR TITLE
make share dialog work from modals

### DIFF
--- a/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
@@ -76,10 +76,17 @@ RCT_EXPORT_METHOD(show:(RCTFBSDKSharingContent)content
   _showResolve = resolve;
   _showReject = reject;
   _shareDialog.shareContent = content;
-  if (!_shareDialog.fromViewController) {
-    _shareDialog.fromViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
-  }
   dispatch_async(dispatch_get_main_queue(), ^{
+    if (!_shareDialog.fromViewController) {
+      UIViewController *viewController = [UIApplication sharedApplication].delegate.window.rootViewController;
+
+      // get the view controller closest to the foreground
+      while (viewController.presentedViewController && !viewController.isBeingDismissed) {
+        viewController = viewController.presentedViewController;
+      }
+
+      _shareDialog.fromViewController = viewController;
+    }
     [_shareDialog show];
   });
 }


### PR DESCRIPTION
When a modal is opened, the `rootViewController` isn't visible, and thus the webview normally opened for authentication cannot be presented.

By looking up the top most view controller and present off of that the view is shown as expected.