### PR TITLE
use helper method for topmost view controller

### DIFF
--- a/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
@@ -83,14 +83,7 @@ RCT_EXPORT_METHOD(show:(RCTFBSDKSharingContent)content
   _shareDialog.shareContent = content;
   dispatch_async(dispatch_get_main_queue(), ^{
     if (!_shareDialog.fromViewController) {
-      UIViewController *viewController = [UIApplication sharedApplication].delegate.window.rootViewController;
-
-      // get the view controller closest to the foreground
-      while (viewController.presentedViewController && !viewController.isBeingDismissed) {
-        viewController = viewController.presentedViewController;
-      }
-
-      _shareDialog.fromViewController = viewController;
+      _shareDialog.fromViewController = RCTPresentedViewController();
     }
     [_shareDialog show];
   });


### PR DESCRIPTION
turns out there's already a helper method to determine the topmost VC.

https://github.com/facebook/react-native/blob/e19d9dec9b3b257b5db3dc77ed8b95b93570f1e3/React/Base/RCTUtils.m#L492

Also I made a mistake in the `isBeingDismissed` part, since that should've been checked on the presented VC, not the presenting.