### PR TITLE
Increase Android Build Tools version to 26 - fix for 'No resource ...…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
     }
     buildTypes {
         release {


### PR DESCRIPTION
… android:keyboardNavigationCluister'

`react-native-fbsdk` is unable to compile as of 2017/12/05 with error message:

> /tmp/sandbox/workspace/node_modules/react-native-fbsdk/android/build/intermediates/res/merged/release/values-v26/values-v26.xml:15:21-54: AAPT: No resource found that matches the given name: attr 'android:keyboardNavigationCluster'.
> /tmp/sandbox/workspace/node_modules/react-native-fbsdk/android/build/intermediates/res/merged/release/values-v26/values-v26.xml:15: error: Error: No resource found that matches the given name: attr 'android:keyboardNavigationCluster'.
> :react-native-fbsdk:processReleaseResources FAILED
>  FAILURE: Build failed with an exception.
> * What went wrong:
>  Execution failed for task ':react-native-fbsdk:processReleaseResources'.
> > com.android.ide.common.process.ProcessException: Failed to execute aapt

Updating build tools to version 26.0.1 from 25.0.3 seems to fix this problem
