### PR TITLE
Avoiding conflict with new fbsdk transitive dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,5 +19,5 @@ android {
 dependencies {
     compile 'com.android.support:appcompat-v7:25.0.0'
     compile 'com.facebook.react:react-native:+' // support react-native-v0.22-rc+
-    compile('com.facebook.android:facebook-android-sdk:4.+')
+    compile 'com.facebook.android:facebook-android-sdk:4.26.0'
 }


### PR DESCRIPTION
The most recent android-fbsk has transitive dependency to android-support v27. This cause issues with React-Native projects.

To try my PR, use:

```json
"react-native-fbsdk": "git+https://github.com/douglasjunior/react-native-fbsdk.git#patch-1"
```

References: 
- https://stackoverflow.com/questions/47664505/android-gradle-sync-issue
- https://stackoverflow.com/questions/47671206/getting-error-when-run-react-native-run-android

