### PR TITLE
fixed how fastfall is being called

### DIFF
--- a/bin/ios_setup.js
+++ b/bin/ios_setup.js
@@ -20,7 +20,7 @@
 const AdmZip = require('adm-zip');
 const ProgressBar = require('progress');
 
-const fall = require('fastfall');
+const fall = require('fastfall')();
 const fs = require('fs');
 const got = require('got');
 const path = require('path');


### PR DESCRIPTION
The latest release includes a change that breaks the ios_setup.js script. If you follow the directions listed here in the [react native facebook sdk guide](https://developers.facebook.com/docs/react-native/configure-ios) running the command `node ios_setup.js [app id] [app name]` currently doesn't work, as the fastfall package isn't being invoked correctly according to [the docs](https://github.com/mcollina/fastfall). This fix reverts the change made in the last commit to allow the command to run successfully.