### PR TITLE
Add logCompletedRegistrationEvent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Pods/
 # Editor
 #
 .idea/
+.gradle/
 
 # node.js
 #

--- a/README.md
+++ b/README.md
@@ -315,6 +315,9 @@ const {
 
 // ...
 
+// Log a completed registration
+AppEventsLogger.logCompletedRegistrationEvent('Facebook')
+
 // Log a $15 purchase.
 AppEventsLogger.logPurchase(15, 'USD', {'param': 'value'})
 ```

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
@@ -20,6 +20,7 @@
 
 package com.facebook.reactnative.androidsdk;
 
+import android.os.Bundle;
 import android.support.annotation.Nullable;
 
 import com.facebook.appevents.AppEventsConstants;
@@ -155,6 +156,16 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void logEvent(String eventName, double valueToSum, ReadableMap parameters) {
         mAppEventLogger.logEvent(eventName, valueToSum, Arguments.toBundle(parameters));
+    }
+
+    /**
+     * Logs a completed registration event with Facebook.
+     */
+    @ReactMethod
+    public void logCompletedRegistrationEvent (String registrationMethod) {
+        Bundle params = new Bundle();
+        params.putString(AppEventsConstants.EVENT_PARAM_REGISTRATION_METHOD, registrationMethod);
+        mAppEventLogger.logEvent(AppEventsConstants.EVENT_NAME_COMPLETED_REGISTRATION, params);
     }
 
     /**

--- a/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
@@ -50,6 +50,13 @@ RCT_EXPORT_METHOD(logEvent:(NSString *)eventName
                accessToken:nil];
 }
 
+RCT_EXPORT_METHOD(logCompletedRegistrationEvent:(NSString *)registrationMethod)
+{
+    NSDictionary *params = @{FBSDKAppEventParameterNameRegistrationMethod : registrationMethod};
+    [FBSDKAppEvents logEvent:FBSDKAppEventNameCompletedRegistration
+                  parameters:params];
+}
+
 RCT_EXPORT_METHOD(logPurchase:(double)purchaseAmount
                      currency:(NSString *)currency
                    parameters:(NSDictionary *)parameters)

--- a/js/FBAppEventsLogger.js
+++ b/js/FBAppEventsLogger.js
@@ -36,7 +36,7 @@ type AppEventsFlushBehavior =
    * Only flush when AppEventsLogger.flush() is explicitly invoked.
    */
   | 'explicit_only';
-type Params = {[key: string]: string | number};
+type Params = { [key: string]: string | number };
 
 module.exports = {
   /**
@@ -66,6 +66,13 @@ module.exports = {
       parameters = args[0];
     }
     AppEventsLogger.logEvent(eventName, valueToSum, parameters);
+  },
+
+  /**
+   * Logs a completed registration event
+   */
+  logCompletedRegistrationEvent(registrationMethod: string) {
+    AppEventsLogger.logCompletedRegistrationEvent(registrationMethod);
   },
 
   /**


### PR DESCRIPTION
### Reasoning
For our implementation we need access to pre-defined standard events provided by `FBSDKAppEventName` or `AppEventsConstants` on Android. However, this lib does not provide explicit access to these event constants.

### Discussion
Our use case only required access to the "Completed Registration" event, so that is the method I have added. 

However, I see two possible paths for this lib, (1) adding individual functions for all the pre-defined standard events, or (2) exporting a set of constants that can be used in React Native, with usage similar to this:

```
import { AppEventsLogger, FBAppEventCompletedRegistration } from 'react-native-fbsdk'

AppEventsLogger.logEvent(FBAppEventCompletedRegsitration)
```
