### PR TITLE
Fixing command to install dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ react-native init YourApp
 
 Install and link the react-native-fbsdk package:
 ```ruby
-react-native install react-native-fbsdk
+npm install react-native-fbsdk
 react-native link react-native-fbsdk
 ```
 ### 3. Configure native projects


### PR DESCRIPTION
It seems like react-native install command is not working. I tried to use it but even though it says installed and linked succesfully it doesn't install the dependency and didn't installed the dependency