### PR TITLE
Update requireNativeComponent to fix flow errors

### DIFF
--- a/js/FBLikeView.js
+++ b/js/FBLikeView.js
@@ -104,6 +104,6 @@ const styles = StyleSheet.create({
 
 LikeView.defaultProps = {style: styles.defaultButtonStyle};
 
-const RCTFBLikeView = requireNativeComponent('RCTFBLikeView', LikeView);
+const RCTFBLikeView = requireNativeComponent('RCTFBLikeView');
 
 module.exports = LikeView;

--- a/js/FBLoginButton.js
+++ b/js/FBLoginButton.js
@@ -151,10 +151,6 @@ LoginButton.defaultProps = {
   style: styles.defaultButtonStyle,
 };
 
-const RCTFBLoginButton = requireNativeComponent(
-  'RCTFBLoginButton',
-  LoginButton,
-  {nativeOnly: {onChange: true}},
-);
+const RCTFBLoginButton = requireNativeComponent('RCTFBLoginButton');
 
 module.exports = LoginButton;

--- a/js/FBSendButton.js
+++ b/js/FBSendButton.js
@@ -66,6 +66,6 @@ SendButton.defaultProps = {
   style: styles.defaultButtonStyle,
 };
 
-const RCTFBSendButton = requireNativeComponent('RCTFBSendButton', SendButton);
+const RCTFBSendButton = requireNativeComponent('RCTFBSendButton');
 
 module.exports = SendButton;

--- a/js/FBShareButton.js
+++ b/js/FBShareButton.js
@@ -67,9 +67,6 @@ ShareButton.defaultProps = {
   style: styles.defaultButtonStyle,
 };
 
-const RCTFBShareButton = requireNativeComponent(
-  'RCTFBShareButton',
-  ShareButton,
-);
+const RCTFBShareButton = requireNativeComponent('RCTFBShareButton');
 
 module.exports = ShareButton;


### PR DESCRIPTION
RN no longer validates native props at runtime. This currently causes flow errors because we pass the extra parameters. This should not break older RN versions, it will just cause it to no longer validate those native props.