### PR TITLE
Fix UI API called on a background thread

### DIFF
--- a/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
@@ -82,10 +82,10 @@ RCT_EXPORT_METHOD(show:(RCTFBSDKSharingContent)content
   _showReject = reject;
   _shareDialog.shareContent = content;
   dispatch_async(dispatch_get_main_queue(), ^{
-    if (!_shareDialog.fromViewController) {
-      _shareDialog.fromViewController = RCTPresentedViewController();
+    if (!self->_shareDialog.fromViewController) {
+      self->_shareDialog.fromViewController = RCTPresentedViewController();
     }
-    [_shareDialog show];
+    [self->_shareDialog show];
   });
 }
 

--- a/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
@@ -62,16 +62,18 @@ RCT_EXPORT_MODULE(FBShareDialog);
 RCT_EXPORT_METHOD(canShow:(RCTFBSDKSharingContent)content resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   _shareDialog.shareContent = content;
-  if ([_shareDialog canShow]) {
-    NSError *error;
-    if ([_shareDialog validateWithError:&error]) {
-      resolve(@YES);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if ([self->_shareDialog canShow]) {
+      NSError *error;
+      if ([self->_shareDialog validateWithError:&error]) {
+        resolve(@YES);
+      } else {
+        reject(@"FacebookSDK", @"SharingContent is invalid", error);
+      }
     } else {
-      reject(@"FacebookSDK", @"SharingContent is invalid", error);
+      resolve(@NO);
     }
-  } else {
-    resolve(@NO);
-  }
+  });
 }
 
 RCT_EXPORT_METHOD(show:(RCTFBSDKSharingContent)content


### PR DESCRIPTION
It seems like whole `canShare` should be called on UI thread.

This fixes a runtime assertion:
```
Main Thread Checker: UI API called on a background thread: -[UIApplication canOpenURL:]
ID: 28595, TID: 7945623, Thread name: (none), Queue name: com.facebook.react.FBShareDialogQueue, QoS: 0
```
