### PR TITLE
Remove public_actions since it's removed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,6 @@ export default class Login extends Component
     return (
       <View>
         <LoginButton
-          publishPermissions={["publish_actions"]}
           onLoginFinished={
             (error, result) => {
               if (error) {


### PR DESCRIPTION
public_actions permission is removed. https://developers.facebook.com/docs/graph-api/changelog/breaking-changes#login-4-24