### PR TITLE
make facebook sdk version fixed

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,8 +5,10 @@ def DEFAULT_BUILD_TOOLS_VERSION             = "26.0.3"
 def DEFAULT_MIN_SDK_VERSION                 = 16
 def DEFAULT_TARGET_SDK_VERSION              = 26
 def DEFAULT_SUPPORT_LIB_VERSION             = "27.0.2"
+def DEFAULT_FACEBOOK_SDK_VERSION            = "4.34.0"
 
 def SUPPORT_LIB_VERSION = rootProject.hasProperty('supportLibVersion') ? rootProject.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
+def FACEBOOK_SDK_VERSION = rootProject.hasProperty('facebookSdkVersion') ? rootProject.facebookSdkVersion : DEFAULT_FACEBOOK_SDK_VERSION
 
 android {
     compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
@@ -27,7 +29,7 @@ android {
 dependencies {
     compile "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
     compile 'com.facebook.react:react-native:+' // support react-native-v0.22-rc+
-    compile 'com.facebook.android:facebook-android-sdk:4.+'
+    compile "com.facebook.android:facebook-android-sdk:${FACEBOOK_SDK_VERSION}"
 }
 
 repositories {


### PR DESCRIPTION
avoid auto-upgrade of android facebook sdk version.
Fix for: https://stackoverflow.com/questions/52113549/app-getting-stuck-with-e-com-facebook-internal-attributionidentifiers