### PR TITLE
React Native 0.56 compatibility (Gradle 3)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,9 +27,9 @@ android {
 }
 
 dependencies {
-    compile "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
-    compile 'com.facebook.react:react-native:+' // support react-native-v0.22-rc+
-    compile "com.facebook.android:facebook-android-sdk:${FACEBOOK_SDK_VERSION}"
+    implementation "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
+    api 'com.facebook.react:react-native:+' // support react-native-v0.22-rc+
+    api "com.facebook.android:facebook-android-sdk:${FACEBOOK_SDK_VERSION}"
 }
 
 repositories {


### PR DESCRIPTION
Extracted RN 0.56 compat from https://github.com/facebook/react-native-fbsdk/pull/387

Could you please release a new version to NPM with all the last fixes please once you merged it

@codytwinton 