### PR TITLE
fix: resolve incompatibility with Facebook SDK 4.38.0 setting version…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ android {
 dependencies {
     compile 'com.android.support:appcompat-v7:27.0.2'
     compile 'com.facebook.react:react-native:+' // support react-native-v0.22-rc+
-    compile 'com.facebook.android:facebook-android-sdk:4.+'
+    compile 'com.facebook.android:facebook-android-sdk:4.37.0'
 }
 
 repositories {

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 public class FBSDKPackage implements ReactPackage {
 
-    public static final String VERSION_TO_RELEASE = "ReactNative-v0.7.0";
+    public static final String VERSION_TO_RELEASE = "ReactNative-v0.7.1";
 
     private CallbackManager mCallbackManager;
     public FBSDKPackage(CallbackManager callbackManager) {

--- a/ios/RCTFBSDK/core/RCTFBSDKInitializer.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKInitializer.m
@@ -40,7 +40,7 @@ RCT_EXPORT_MODULE();
 - (instancetype)init
 {
   if ((self = [super init])) {
-    [FBSDKSettings setUserAgentSuffix:@"ReactNative-v0.7.0"];
+    [FBSDKSettings setUserAgentSuffix:@"ReactNative-v0.7.1"];
   }
   return self;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fbsdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Facebook SDK support for React Native apps.",
   "main": "./js/index.js",
   "author": {

--- a/sample/HelloFacebook/package.json
+++ b/sample/HelloFacebook/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": ">=15.4.2",
     "react-native": ">=0.40.0",
-    "react-native-fbsdk": ">=0.7.0"
+    "react-native-fbsdk": ">=0.7.1"
   },
   "jest": {
     "preset": "jest-react-native"


### PR DESCRIPTION
This should fix **_tag 0.7.0_** about the problem we are facing due to the latest changes of FBSDK 4.38+.

+ Thread about the bug: https://developers.facebook.com/support/bugs/260814197942050/
+ Fix sugestion: https://developers.facebook.com/support/bugs/260814197942050/?comment_id=260920501264753

Obs: This shouldn't be merged into master, instead create a new tag 0.7.1
