### PR TITLE
Increase xcode package version to minimal 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "plist": "^2.1.0",
     "progress": "^2.0.0",
     "pump": "^1.0.2",
-    "xcode": "^0.9.3"
+    "xcode": "^1.0.0"
   },
   "peerDependencies": {
     "react-native": ">=0.44.0",


### PR DESCRIPTION
Based on changelog https://github.com/apache/cordova-node-xcode/blob/master/RELEASENOTES.md is version 1.0.0 stabilized version 0.9. Anyway it will be complatible with React Native 0.57.4 and up.