### PR TITLE
Update Readme for iOS compilation problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Before you can run the project, follow the [Getting Started Guide](https://devel
 
 #### 3.2 iOS project
 The react-native-fbsdk has been linked by rnpm, the next step will be downloading and linking the native Facebook SDK for iOS.
-Make sure you have the latest [Xcode](https://developer.apple.com/xcode/) installed. Open the .xcodeproj in Xcode found in the `ios` subfolder from your project's root directory. Now, follow ***all the steps*** in the [Getting Started Guide](https://developers.facebook.com/docs/ios/getting-started/) for Facebook SDK for iOS. Along with `FBSDKCoreKit.framework`, don't forget to import `FBSDKShareKit.framework` and `FBSDKLoginKit.framework` into your Xcode project.
+Make sure you have the latest [Xcode](https://developer.apple.com/xcode/) installed. Open the .xcodeproj in Xcode found in the `ios` subfolder from your project's root directory. Now, follow ***all the steps except the pod install (Step 2)*** in the [Getting Started Guide](https://developers.facebook.com/docs/ios/getting-started/) for Facebook SDK for iOS. Along with `FBSDKCoreKit.framework`, don't forget to import `FBSDKShareKit.framework` and `FBSDKLoginKit.framework` into your Xcode project.
 
 **If you're using react native's RCTLinkingManager**
 


### PR DESCRIPTION
***all the steps except the pod install (Step 2)*** 
Using : 
```
    "react": "16.3.1",
    "react-native": "0.55.4",
    "react-native-fbsdk": "^0.8.0",
```
In the step 2 of the guide it is suggested to add `pod 'FacebookSDK'` which is creating issues in the iOS  project with the `react-native-fbsdk` lib

**Example of issues :** 

During `react-native run-ios`: 
```
** BUILD FAILED **

The following build commands failed:

    CompileC /Users/xxx/Documents/ReactJS/xxx/ios/build/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/FBSDKCoreKit.build/Objects-normal/x86_64/FBSDKAccessTokenCache.o FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKAccessTokenCache.m normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.compiler
```

on Xcode : 
```
Duplicate interface definition for class 'FBSDKAccessToken'
```