### PR TITLE
Add bindings for AppEvents.setUserData

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ def DEFAULT_BUILD_TOOLS_VERSION             = "26.0.3"
 def DEFAULT_MIN_SDK_VERSION                 = 16
 def DEFAULT_TARGET_SDK_VERSION              = 26
 def DEFAULT_SUPPORT_LIB_VERSION             = "27.0.2"
-def DEFAULT_FACEBOOK_SDK_VERSION            = "4.34.0"
+def DEFAULT_FACEBOOK_SDK_VERSION            = "4.38.1"
 
 def SUPPORT_LIB_VERSION = rootProject.hasProperty('supportLibVersion') ? rootProject.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
 def FACEBOOK_SDK_VERSION = rootProject.hasProperty('facebookSdkVersion') ? rootProject.facebookSdkVersion : DEFAULT_FACEBOOK_SDK_VERSION

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
@@ -223,6 +223,31 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
        mAppEventLogger.updateUserProperties(Arguments.toBundle(parameters), null);
      }
 
+    private @Nullable String getNullableString(ReadableMap data, String key) {
+      return data.hasKey(key) ? data.getString(key) : null;
+    }
+
+    /**
+     * Set additional data about the user to increase chances of matching a Facebook user.
+     *
+     * @param userData Key-value pairs representing user data and their values.
+     */
+    @ReactMethod
+    public void setUserData(ReadableMap userData) {
+      AppEventsLogger.setUserData(
+        getNullableString(userData, "email"),
+        getNullableString(userData, "firstName"),
+        getNullableString(userData, "lastName"),
+        getNullableString(userData, "phone"),
+        getNullableString(userData, "dateOfBirth"),
+        getNullableString(userData, "gender"),
+        getNullableString(userData, "city"),
+        getNullableString(userData, "state"),
+        getNullableString(userData, "zip"),
+        getNullableString(userData, "country")
+      );
+    }
+
     /**
      * Explicitly flush any stored events to the server.  Implicit flushes may happen depending on
      * the value of getFlushBehavior.  This method allows for explicit, app invoked flushing.

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
@@ -69,7 +69,8 @@ public final class Utility {
                 reactArrayToStringList(accessTokenMap.getArray("declinedPermissions")),
                 accessTokenSource,
                 expirationTime,
-                lastRefreshTime
+                lastRefreshTime,
+                null
         );
     }
 

--- a/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
@@ -81,6 +81,20 @@ RCT_EXPORT_METHOD(updateUserProperties:(NSDictionary *)parameters)
                                handler:nil];
 }
 
+RCT_EXPORT_METHOD(setUserData:(NSDictionary *)userData)
+{
+  [FBSDKAppEvents setUserEmail:userData[@"email"]
+                     firstName:userData[@"firstName"]
+                      lastName:userData[@"lastName"]
+                         phone:userData[@"phone"]
+                   dateOfBirth:userData[@"dateOfBirth"]
+                        gender:userData[@"gender"]
+                          city:userData[@"city"]
+                         state:userData[@"state"]
+                           zip:userData[@"zip"]
+                       country:userData[@"country"]];
+}
+
 RCT_EXPORT_METHOD(setFlushBehavior:(FBSDKAppEventsFlushBehavior)flushBehavior)
 {
   [FBSDKAppEvents setFlushBehavior:flushBehavior];

--- a/js/FBAppEventsLogger.js
+++ b/js/FBAppEventsLogger.js
@@ -38,6 +38,24 @@ type AppEventsFlushBehavior =
   | 'explicit_only';
 type Params = {[key: string]: string | number};
 
+/**
+ * Info about a user to increase chances of matching a Facebook user.
+ * See https://developers.facebook.com/docs/app-events/advanced-matching for
+ * more info about the expected format of each field.
+ */
+type UserData = $ReadOnly<{|
+  email?: ?string,
+  firstName?: ?string,
+  lastName?: ?string,
+  phone?: ?string,
+  dateOfBirth?: ?string,
+  gender?: ?('m' | 'f'),
+  city?: ?string,
+  state?: ?string,
+  zip?: ?string,
+  country?: ?string,
+|}>;
+
 module.exports = {
   /**
    * Sets the current event flushing behavior specifying when events
@@ -114,6 +132,13 @@ module.exports = {
    */
   updateUserProperties(parameters: Params) {
     AppEventsLogger.updateUserProperties(parameters);
+  },
+
+  /**
+   * Set additional data about the user to increase chances of matching a Facebook user.
+   */
+  setUserData(userData: UserData) {
+    AppEventsLogger.setUserData(userData);
   },
 
   /**


### PR DESCRIPTION
This adds bindings for AppEvents.setUserData which was added recently to the fb sdk. See https://developers.facebook.com/docs/app-events/advanced-matching.

Test Plan:

Tested the changes locally on iOS and android by calling the setUserData method and making sure all parameters get passed correctly.
