### PR TITLE
Use `$(HOME)` instead of `~` for Xcode 10

### DIFF
--- a/ios/RCTFBSDK.xcodeproj/project.pbxproj
+++ b/ios/RCTFBSDK.xcodeproj/project.pbxproj
@@ -365,7 +365,7 @@
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"~/Documents/FacebookSDK",
+					"$(HOME)/Documents/FacebookSDK",
 					"$(PROJECT_DIR)/../../../ios/Frameworks",
 					"$(PROJECT_DIR)/../../../ios/Pods",
 				);


### PR DESCRIPTION
I'm not sure _why_ Xcode 10 stopped consistently resolving `~` to the user's home directory, but here we are.

See also: https://stackoverflow.com/questions/35590903/xcode-always-says-fbsdksharekit-fbsdksharekit-h-file-not-found

Fixes #414