### PR TITLE
Keep fixed dependency versions

### DIFF
--- a/react-native-fbsdk.podspec
+++ b/react-native-fbsdk.podspec
@@ -14,17 +14,17 @@ Pod::Spec.new do |s|
   s.dependency      'React'
 
   s.subspec 'Core' do |ss|
-    ss.dependency     'FBSDKCoreKit'
+    ss.dependency     'FBSDKCoreKit', '4.38.1'
     ss.source_files = 'ios/RCTFBSDK/core/*.{h,m}'
   end
 
   s.subspec 'Login' do |ss|
-    ss.dependency     'FBSDKLoginKit'
+    ss.dependency     'FBSDKLoginKit', '4.38.1'
     ss.source_files = 'ios/RCTFBSDK/login/*.{h,m}'
   end
 
   s.subspec 'Share' do |ss|
-    ss.dependency     'FBSDKShareKit'
+    ss.dependency     'FBSDKShareKit', '4.38.1'
     ss.source_files = 'ios/RCTFBSDK/share/*.{h,m}'
   end
 end


### PR DESCRIPTION
When you install lib with Cocoapods it will install all FBSDK libs to `0.39.0` and it broke some functionality. 
At least login is broken now for `0.8.0` or `0.9.0`

It was working good earlier with `FBSDK 0.38.1`

Should fix issue:
https://github.com/facebook/react-native-fbsdk/issues/431