### PR TITLE
Modify Framework Search Path Syntax

### DIFF
--- a/ios/RCTFBSDK.xcodeproj/project.pbxproj
+++ b/ios/RCTFBSDK.xcodeproj/project.pbxproj
@@ -390,7 +390,7 @@
 				COPY_PHASE_STRIP = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"~/Documents/FacebookSDK",
+					"$(HOME)/Documents/FacebookSDK",
 					"$(PROJECT_DIR)/../../../ios/Frameworks",
 					"$(PROJECT_DIR)/../../../ios/Pods",
 				);


### PR DESCRIPTION
See https://github.com/facebook/react-native-fbsdk/pull/417 for context.

@reidab 's pull request (#417) updated the framework search path syntax for compatibility with Xcode 10 (original issue #414). However, only the debug target's build settings were changed. This pull request modifies the release target's build settings as well. This will allow both debug and release targets to compile with Xcode 10. The screenshot below illustrates the mismatched build settings:

![debug](https://user-images.githubusercontent.com/10404365/50248499-df72bc80-03a0-11e9-9fe6-b510f4c309b7.png)
![release](https://user-images.githubusercontent.com/10404365/50248500-e0a3e980-03a0-11e9-842f-6c5864367db2.png)