### PR TITLE
FacebookSDK default `framework search paths` for those who dragged and dropped and checked `copy items if needed`

### DIFF
--- a/ios/RCTFBSDK.xcodeproj/project.pbxproj
+++ b/ios/RCTFBSDK.xcodeproj/project.pbxproj
@@ -366,6 +366,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(HOME)/Documents/FacebookSDK",
+					"$(PROJECT_DIR)/../../../ios",
 					"$(PROJECT_DIR)/../../../ios/Frameworks",
 					"$(PROJECT_DIR)/../../../ios/Pods",
 				);


### PR DESCRIPTION
Xcode automatically saves the `.frameworks` files into `${REACT_NATIVE_PROJECT_DIR}/ios` directory when you **drag and drop directly to the `Frameworks/` folder and check `copy items if needed`**!

It would be convenient to reference that path for those who add the files that way. 

I personally prefer adding files that way because I do not have to keep my sdk files into `~/Documents`. 
Also your colleagues will automatically download the files from git pull(they don't need to download the sdk again and put it into `~/Downloads`) when setting up!