### PR TITLE
Use RCTComponentEvent

### DIFF
--- a/ios/RCTFBSDK/login/RCTFBSDKLoginButtonManager.m
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginButtonManager.m
@@ -19,6 +19,7 @@
 #import "RCTFBSDKLoginButtonManager.h"
 
 #import <React/RCTBridge.h>
+#import <React/RCTComponentEvent.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTUtils.h>
 #import <React/UIView+React.h>
@@ -60,9 +61,8 @@ RCT_CUSTOM_VIEW_PROPERTY(tooltipBehaviorIOS, FBSDKLoginButtonTooltipBehavior, FB
 
 - (void)loginButton:(FBSDKLoginButton *)loginButton didCompleteWithResult:(FBSDKLoginManagerLoginResult *)result error:(NSError *)error
 {
-  NSDictionary *event = @{
+  NSDictionary *body = @{
     @"type": @"loginFinished",
-    @"target": loginButton.reactTag,
     @"error": error ? RCTJSErrorFromNSError(error) : [NSNull null],
     @"result": error ? [NSNull null] : @{
       @"isCancelled": @(result.isCancelled),
@@ -70,16 +70,23 @@ RCT_CUSTOM_VIEW_PROPERTY(tooltipBehaviorIOS, FBSDKLoginButtonTooltipBehavior, FB
       @"declinedPermissions": result.isCancelled ? [NSNull null] : result.declinedPermissions.allObjects,
     },
   };
-  [self.bridge.eventDispatcher sendInputEventWithName:@"topChange" body:event];
+  
+  RCTComponentEvent *event = [[RCTComponentEvent alloc] initWithName:@"topChange"
+                                                             viewTag:loginButton.reactTag
+                                                                body:body];
+  [self.bridge.eventDispatcher sendEvent:event];
 }
 
 - (void)loginButtonDidLogOut:(FBSDKLoginButton *)loginButton
 {
-  NSDictionary *event = @{
-    @"target": loginButton.reactTag,
+  NSDictionary *body = @{
     @"type": @"logoutFinished",
   };
-  [self.bridge.eventDispatcher sendInputEventWithName:@"topChange" body:event];
+
+  RCTComponentEvent *event = [[RCTComponentEvent alloc] initWithName:@"topChange"
+                                                             viewTag:loginButton.reactTag
+                                                                body:body];
+  [self.bridge.eventDispatcher sendEvent:event];
 }
 
 @end


### PR DESCRIPTION
Related to https://github.com/facebook/react-native/pull/15894

Use RCTComponentEvent instead of the deprecated [sendInputEventWithName:body:] which will be removed when https://github.com/facebook/react-native/pull/15894 lands.

This PR should only be merged once https://github.com/facebook/react-native/pull/15894 has landed and made it to a stable release, since RCTComponentEvent does not currently exist in RN master.