### PR TITLE
Set version tag for Podspec to align with project

### DIFF
--- a/react-native-fbsdk.podspec
+++ b/react-native-fbsdk.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.author        = { 'dzhuowen' => 'dzhuowen@fb.com' }
   s.license       = package['license']
   s.homepage      = package['homepage']
-  s.source        = { :git => 'https://github.com/facebook/react-native-fbsdk.git' }
+  s.source        = { :git => 'https://github.com/facebook/react-native-fbsdk.git', :tag => s.version }
   s.platform      = :ios, '7.0'
   s.dependency      'React'
 


### PR DESCRIPTION
The podspec for the project did not set a git tag.
This could lead to things which depend on it always grabbing latest
master even though they point to a podspec from a set point in time.

Updated to automatically have the git tag match the podspec version.
