### PR TITLE
[iOS][Fix build] Fix search paths

### DIFF
--- a/ios/RCTFBSDK.xcodeproj/project.pbxproj
+++ b/ios/RCTFBSDK.xcodeproj/project.pbxproj
@@ -375,6 +375,7 @@
 					"${SRCROOT}/../../../ios/Pods/FBSDKCoreKit/FBSDKCoreKit",
 					"${SRCROOT}/../../../ios/Pods/FBSDKLoginKit/FBSDKLoginKit",
 					"${SRCROOT}/../../../ios/Pods/FBSDKShareKit/FBSDKShareKit",
+					"${SRCROOT}/../../../ios/Pods/Headers/Public",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -400,6 +401,7 @@
 					"${SRCROOT}/../../../ios/Pods/FBSDKCoreKit/FBSDKCoreKit",
 					"${SRCROOT}/../../../ios/Pods/FBSDKLoginKit/FBSDKLoginKit",
 					"${SRCROOT}/../../../ios/Pods/FBSDKShareKit/FBSDKShareKit",
+					"${SRCROOT}/../../../ios/Pods/Headers/Public",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
When using Podfile build fails and I need manually update Header Search Paths
```
  pod 'FBSDKCoreKit', '~> 4.42.0'
  pod 'FBSDKLoginKit', '~> 4.42.0'
  pod 'FBSDKShareKit', '~> 4.42.0'
```

Fixes #501