### PR TITLE
specify tag for source in podspec

### DIFF
--- a/react-native-fbsdk.podspec
+++ b/react-native-fbsdk.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.author        = { 'dzhuowen' => 'dzhuowen@fb.com' }
   s.license       = package['license']
   s.homepage      = package['homepage']
-  s.source        = { :git => 'https://github.com/facebook/react-native-fbsdk.git' }
+  s.source        = { :git => 'https://github.com/facebook/react-native-fbsdk.git', :tag => package['version'] }
   s.platform      = :ios, '7.0'
   s.dependency      'React'
 


### PR DESCRIPTION
When published to a private podspec repo, cocoapods would download the source from master, instead of the specific version.
