### PR TITLE
Duplicate case in LoginBehaviorToString removed

### DIFF
--- a/ios/RCTFBSDK/login/RCTFBSDKLoginManager.m
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginManager.m
@@ -130,15 +130,6 @@ static NSString *LoginBehaviorToString(FBSDKLoginBehavior loginBehavior)
     case FBSDKLoginBehaviorBrowser:
       result = @"browser";
       break;
-    case FBSDKLoginBehaviorNative:
-      result = @"native";
-      break;
-    case FBSDKLoginBehaviorSystemAccount:
-      result = @"system-account";
-      break;
-    case FBSDKLoginBehaviorWeb:
-      result = @"web";
-      break;
     default:
       break;
   }


### PR DESCRIPTION
Fixes #509

The build fails in iOS with Error duplicate case value. Tested in Emulator