### PR TITLE
Migrate to Android X

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,13 +1,11 @@
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION             = 26
-def DEFAULT_BUILD_TOOLS_VERSION             = "26.0.3"
+def DEFAULT_COMPILE_SDK_VERSION             = 28
+def DEFAULT_BUILD_TOOLS_VERSION             = "28.0.3"
 def DEFAULT_MIN_SDK_VERSION                 = 16
-def DEFAULT_TARGET_SDK_VERSION              = 26
-def DEFAULT_SUPPORT_LIB_VERSION             = "27.0.2"
+def DEFAULT_TARGET_SDK_VERSION              = 28
 def DEFAULT_FACEBOOK_SDK_VERSION            = "4.38.1"
 
-def SUPPORT_LIB_VERSION = rootProject.hasProperty('supportLibVersion') ? rootProject.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
 def FACEBOOK_SDK_VERSION = rootProject.hasProperty('facebookSdkVersion') ? rootProject.facebookSdkVersion : DEFAULT_FACEBOOK_SDK_VERSION
 
 android {
@@ -27,7 +25,7 @@ android {
 }
 
 dependencies {
-    implementation "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
+    implementation "androidx.appcompat:appcompat:1.0.2"
     api 'com.facebook.react:react-native:+' // support react-native-v0.22-rc+
     api "com.facebook.android:facebook-android-sdk:${FACEBOOK_SDK_VERSION}"
 }

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
@@ -20,7 +20,7 @@
 
 package com.facebook.reactnative.androidsdk;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.appevents.AppEventsConstants;
 import com.facebook.appevents.AppEventsLogger;

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBLikeViewManager.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBLikeViewManager.java
@@ -20,16 +20,13 @@
 
 package com.facebook.reactnative.androidsdk;
 
-import android.content.Intent;
-import android.support.annotation.Nullable;
-import android.util.Log;
-
-import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.share.widget.LikeView;
+
+import androidx.annotation.Nullable;
 
 
 public class FBLikeViewManager extends SimpleViewManager<RCTLikeView> {

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginButtonManager.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginButtonManager.java
@@ -20,7 +20,7 @@
 
 package com.facebook.reactnative.androidsdk;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.CallbackManager;
 import com.facebook.login.DefaultAudience;


### PR DESCRIPTION
To be compatible with RN 0.60+ we need to change from the old support lib to androidx. The only usage we have is the `Nullable` annotation so the changes are minor.

## Test plan

Tested the it builds in an example app with RN 0.60.0-rc.1