### PR TITLE
Correct sharing a video with preview photo

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -67,18 +67,18 @@ PODS:
     - React-cxxreact (= 0.60.0-rc.1)
     - React-jsi (= 0.60.0-rc.1)
   - React-jsinspector (0.60.0-rc.1)
-  - react-native-fbsdk (0.9.0):
+  - react-native-fbsdk (1.0.0-rc.0):
     - React
-    - react-native-fbsdk/Core (= 0.9.0)
-    - react-native-fbsdk/Login (= 0.9.0)
-    - react-native-fbsdk/Share (= 0.9.0)
-  - react-native-fbsdk/Core (0.9.0):
+    - react-native-fbsdk/Core (= 1.0.0-rc.0)
+    - react-native-fbsdk/Login (= 1.0.0-rc.0)
+    - react-native-fbsdk/Share (= 1.0.0-rc.0)
+  - react-native-fbsdk/Core (1.0.0-rc.0):
     - FBSDKCoreKit (~> 5.0.0)
     - React
-  - react-native-fbsdk/Login (0.9.0):
+  - react-native-fbsdk/Login (1.0.0-rc.0):
     - FBSDKLoginKit (~> 5.0.0)
     - React
-  - react-native-fbsdk/Share (0.9.0):
+  - react-native-fbsdk/Share (1.0.0-rc.0):
     - FBSDKShareKit (~> 5.0.0)
     - React
   - React-RCTActionSheet (0.60.0-rc.1):
@@ -195,27 +195,27 @@ SPEC CHECKSUMS:
   FBSDKShareKit: 8695bbb97c18a381bbf2851a3f24f95a59121b82
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  React: 771da41f95c2938a4268d0064dae874efca76d47
-  React-Core: c6be9e64310cda9bded86059005a2be9cfcd83d1
-  React-cxxreact: 17ab2493f0071b3587a2fa8874d374ab6df17d91
-  React-DevSupport: e47afce62e4d32d81df53ec593bf490101954c63
-  React-fishhook: 689293b246ac0d2aa2aae7bac08719d69ff4b6db
-  React-jsi: 6d2a594ad2281e6646fa3ac665b95554d0e3c0b1
-  React-jsiexecutor: 418cedeadc8ae5096574e6b199a6b025734397d5
-  React-jsinspector: 3d54eec4e664fad1fe6ecf3fb2554b53d379fb9f
-  react-native-fbsdk: 906887ad3b903b75e50b07683cf7c37f1b73e310
-  React-RCTActionSheet: 37f59304f286148e9bf0fdd8683e6d959998bd58
-  React-RCTAnimation: 43948fbaed6ac32285130d0bf6543d685d271d01
-  React-RCTBlob: f7614a4b3631c8c0048516972cb48ab21e3229f7
-  React-RCTImage: 0af567e4ecc3fe76469ccd93e25f8403aa953917
-  React-RCTLinking: c26bd5665a0226654e7d33f674bb0083a5f8822b
-  React-RCTNetwork: 467aab0787fb8d940be0767de88f18c6d3fbda24
-  React-RCTSettings: 79d28ecf44cf144432c1001bbca2e93d4d7a4e7f
-  React-RCTText: 1b3e71979b7de522c797d5c437107897f0f8aa48
-  React-RCTVibration: d3a10d7c6c55df9021432a0a33507331757a302b
-  React-RCTWebSocket: ea37aa224c6c3dab458b142c0d17c42b3f80e989
-  yoga: 6cc9ed1b0509efe6b6519dc5f44af3c7b9dfb7a5
+  React: c438ccc7e14e86d4702bb92d7e262f549ffaa995
+  React-Core: c76495f5c14e73c0f803b89c3fa83f804da61bd6
+  React-cxxreact: f64bc64cf4682d6ea5a064f6017da72482858682
+  React-DevSupport: 30336bca00f72681eac995d21a31b963e7d5cfec
+  React-fishhook: 73dc8058ca42828cc92e8fbba6cd9571100e10ca
+  React-jsi: 40f467ff088c811c6630acccb4aea57ea7ccb1b5
+  React-jsiexecutor: e4b4717060a0cd8d0270323b5655a68c95432efd
+  React-jsinspector: 044105eea064aec81adc5e4d777a8f6589e7d094
+  react-native-fbsdk: 73370971d27ac3c73716e9431093e1a4388289cc
+  React-RCTActionSheet: 08864c609d9f959abf3d51fdd93f8bc6e91f21eb
+  React-RCTAnimation: a4547e9fac2627ded3df9d302f5558b475faf819
+  React-RCTBlob: 62d5c263a2adb8f7a2cafd601beba18a2d99cbbb
+  React-RCTImage: 963859de2b05d2037d1b7842cdbddc8d7f3a2f3b
+  React-RCTLinking: 5998a7db9a6156ed112b006d01f76b2d1cc83d98
+  React-RCTNetwork: 0b676e8194f3f893db813007d37e37e9820173a3
+  React-RCTSettings: fdd7606f1b6050eced69fc6046d5db6768aefd57
+  React-RCTText: 36c0532feb5521cb295ba80e7e44b70cf1c36fc7
+  React-RCTVibration: dabb8d59bb47e1d9124b3f77bfdc1b33d42b0a74
+  React-RCTWebSocket: f32b93e0953d7c07fd5dd45305406282cfdc95cf
+  yoga: 88c514f310aff89b94a14c5fbf44b95735af0cb7
 
 PODFILE CHECKSUM: 166764d2c07190c305e293455e6e35c162854eb0
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.5.3

--- a/example/ios/RNFBSDKExample.xcodeproj/project.pbxproj
+++ b/example/ios/RNFBSDKExample.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0EF5B78486F2856ACDCEA373 /* Pods-RNFBSDKExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample.release.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample.release.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* RNFBSDKExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RNFBSDKExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = RNFBSDKExample/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = RNFBSDKExample/AppDelegate.m; sourceTree = "<group>"; };
@@ -24,11 +23,10 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = RNFBSDKExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = RNFBSDKExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = RNFBSDKExample/main.m; sourceTree = "<group>"; };
-		249908D268DE98AF24F835A1 /* Pods-RNFBSDKExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample.debug.xcconfig"; sourceTree = "<group>"; };
 		2D16E6891FA4F8E400B85C8A /* libReact.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libReact.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		870A7DD6F7C14CB1ADF66F14 /* libPods-RNFBSDKExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNFBSDKExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		B8B51A8B9E573C31AA602BB8 /* Pods-RNFBSDKExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample.debug.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample.debug.xcconfig"; sourceTree = "<group>"; };
-		C91B992100F02D057FFBC015 /* Pods-RNFBSDKExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample.release.xcconfig"; path = "Pods/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample.release.xcconfig"; sourceTree = "<group>"; };
+		99F281F6E6DCAC235749C4DC /* Pods-RNFBSDKExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample.debug.xcconfig"; sourceTree = "<group>"; };
+		C10E104DB653CE36B9B956A3 /* Pods-RNFBSDKExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample.release.xcconfig"; path = "Pods/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -58,6 +56,15 @@
 			name = RNFBSDKExample;
 			sourceTree = "<group>";
 		};
+		2350D7AAB3ED3E881DB63F1B /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				99F281F6E6DCAC235749C4DC /* Pods-RNFBSDKExample.debug.xcconfig */,
+				C10E104DB653CE36B9B956A3 /* Pods-RNFBSDKExample.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -68,24 +75,13 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		38D44C3AF5BAA2D68A0F7609 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				B8B51A8B9E573C31AA602BB8 /* Pods-RNFBSDKExample.debug.xcconfig */,
-				0EF5B78486F2856ACDCEA373 /* Pods-RNFBSDKExample.release.xcconfig */,
-				249908D268DE98AF24F835A1 /* Pods-RNFBSDKExample.debug.xcconfig */,
-				C91B992100F02D057FFBC015 /* Pods-RNFBSDKExample.release.xcconfig */,
-			);
-			path = Pods;
-			sourceTree = "<group>";
-		};
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
 				13B07FAE1A68108700A75B9A /* RNFBSDKExample */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
-				38D44C3AF5BAA2D68A0F7609 /* Pods */,
+				2350D7AAB3ED3E881DB63F1B /* Pods */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -251,7 +247,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 249908D268DE98AF24F835A1 /* Pods-RNFBSDKExample.debug.xcconfig */;
+			baseConfigurationReference = 99F281F6E6DCAC235749C4DC /* Pods-RNFBSDKExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
@@ -271,7 +267,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C91B992100F02D057FFBC015 /* Pods-RNFBSDKExample.release.xcconfig */;
+			baseConfigurationReference = C10E104DB653CE36B9B956A3 /* Pods-RNFBSDKExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;

--- a/example/ios/RNFBSDKExample.xcodeproj/project.pbxproj
+++ b/example/ios/RNFBSDKExample.xcodeproj/project.pbxproj
@@ -186,7 +186,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample-resources.sh",
+				"${SRCROOT}/Pods/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample-resources.sh",
 				"${PODS_ROOT}/FBSDKCoreKit/FacebookSDKStrings.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
@@ -197,7 +197,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E3AE85C98B0DE57952EBBE93 /* [CP] Check Pods Manifest.lock */ = {
@@ -251,7 +251,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B8B51A8B9E573C31AA602BB8 /* Pods-RNFBSDKExample.debug.xcconfig */;
+			baseConfigurationReference = 249908D268DE98AF24F835A1 /* Pods-RNFBSDKExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
@@ -271,7 +271,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0EF5B78486F2856ACDCEA373 /* Pods-RNFBSDKExample.release.xcconfig */;
+			baseConfigurationReference = C91B992100F02D057FFBC015 /* Pods-RNFBSDKExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;

--- a/ios/RCTFBSDK/share/RCTConvert+FBSDKSharingContent.m
+++ b/ios/RCTFBSDK/share/RCTConvert+FBSDKSharingContent.m
@@ -111,6 +111,10 @@ static FBSDKShareVideoContent *RCTBuildVideoContent(NSDictionary *contentData)
   NSDictionary *videoData = [RCTConvert NSDictionary:contentData[@"video"]];
   NSURL *videoURL = [RCTConvert NSURL:videoData[@"localUrl"]];
   FBSDKShareVideo *video = [FBSDKShareVideo videoWithVideoURL:videoURL];
+  if (contentData[@"previewPhoto"]) {
+    FBSDKSharePhoto *previewPhoto = RCTBuildPhoto([RCTConvert NSDictionary:contentData[@"previewPhoto"]]);
+    video.previewPhoto = previewPhoto;
+  }
   videoContent.video = video;
   videoContent.contentURL = [RCTConvert NSURL:contentData[@"contentUrl"]];
   return videoContent;

--- a/ios/RCTFBSDK/share/RCTConvert+FBSDKSharingContent.m
+++ b/ios/RCTFBSDK/share/RCTConvert+FBSDKSharingContent.m
@@ -132,9 +132,8 @@ static FBSDKShareOpenGraphContent *RCTBuildOpenGraphContent(NSDictionary *conten
 static FBSDKShareOpenGraphAction *RCTBuildOpenGraphAction(NSDictionary *actionData)
 {
   FBSDKShareOpenGraphAction *action = nil;
-  NSString *actionType = nil;
   if (actionData) {
-    actionType = [RCTConvert NSString:actionData[@"actionType"]];
+    NSString *actionType = [RCTConvert NSString:actionData[@"actionType"]];
     action = [[FBSDKShareOpenGraphAction alloc] initWithActionType:actionType];
     NSString *actionDataKey = actionData[@"_properties"] ? @"_properties" : @"$ShareOpenGraphValueContainer_properties";
     NSDictionary *properties = [RCTConvert NSDictionary:actionData[actionDataKey]];

--- a/js/models/FBShareVideoContent.js
+++ b/js/models/FBShareVideoContent.js
@@ -59,4 +59,9 @@ export type ShareVideoContent = {
    * Title of the video.
    */
   contentTitle?: string,
+
+  /**
+   * The photo that represents the video.
+   */
+  previewPhoto?: SharePhoto,
 };


### PR DESCRIPTION
Previously this feature was removed from iOS and JS side of the library. It turned out that it is supported by the native FBSDK, so this PR adds it back in, the correct way.

As an extra I've fixed the iOS build issue of the example app.

The example app builds and runs.