### PR TITLE
Correct missing VERSION_TO_RELEASE symbol

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
@@ -41,7 +41,6 @@ public class FBSDKPackage implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(
             ReactApplicationContext reactContext) {
-        InternalSettings.setCustomUserAgent(VERSION_TO_RELEASE);
         return Arrays.<NativeModule>asList(
                 new FBAccessTokenModule(reactContext),
                 new FBAppEventsLoggerModule(reactContext),


### PR DESCRIPTION
Previously the declaration was removed but the reference to it wasn't.

Example app builds and runs.