### PR TITLE
Minimize binary footprint on android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,9 +27,9 @@ android {
 dependencies {
     implementation "androidx.appcompat:appcompat:1.0.+"
     api 'com.facebook.react:react-native:+'
-    api "com.facebook.android:facebook-core:${FACEBOOK_SDK_VERSION}"
-    api "com.facebook.android:facebook-login:${FACEBOOK_SDK_VERSION}"
-    api "com.facebook.android:facebook-share:${FACEBOOK_SDK_VERSION}"
+    implementation "com.facebook.android:facebook-core:${FACEBOOK_SDK_VERSION}"
+    implementation "com.facebook.android:facebook-login:${FACEBOOK_SDK_VERSION}"
+    implementation "com.facebook.android:facebook-share:${FACEBOOK_SDK_VERSION}"
 }
 
 repositories {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,9 @@ android {
 dependencies {
     implementation "androidx.appcompat:appcompat:1.0.+"
     api 'com.facebook.react:react-native:+'
-    api "com.facebook.android:facebook-android-sdk:${FACEBOOK_SDK_VERSION}"
+    api "com.facebook.android:facebook-core:${FACEBOOK_SDK_VERSION}"
+    api "com.facebook.android:facebook-login:${FACEBOOK_SDK_VERSION}"
+    api "com.facebook.android:facebook-share:${FACEBOOK_SDK_VERSION}"
 }
 
 repositories {


### PR DESCRIPTION
Instead of pulling in the whole FBSDK just pull in the modules we are using.

Example app builds and runs if we consider #556 merged.