### PR TITLE
fix: tags are now prefixed with a `v`

### DIFF
--- a/react-native-fbsdk.podspec
+++ b/react-native-fbsdk.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.author        = { 'dzhuowen' => 'dzhuowen@fb.com' }
   s.license       = package['license']
   s.homepage      = package['homepage']
-  s.source        = { :git => 'https://github.com/facebook/react-native-fbsdk.git', :tag => package['version'] }
+  s.source        = { :git => 'https://github.com/facebook/react-native-fbsdk.git', :tag => "v#{package['version']}" }
   s.platform      = :ios, '7.0'
   s.dependency      'React'
 


### PR DESCRIPTION
Since I've proposed to add the tag to podspec, the tags have changed to use a `v` prefix (which is a good thing IMO). But this requires a change to the podspec.