### PR TITLE
Remove the need to pass CallbackManager to FBSDKPackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,32 +56,15 @@ react-native link react-native-fbsdk
 
 Assuming you have [Android Studio](http://developer.android.com/sdk/index.html) installed, open the project with Android Studio.
 
-Go to `MainApplication.java` and `MainActivity.java` under `app/src/main/java/com/<project name>/` to complete setup.
-
-In `MainApplication.java`,
-
-Add an instance variable of type `CallbackManager` and its getter.
-
-```java
-import com.facebook.CallbackManager;
-import com.facebook.FacebookSdk;
-import com.facebook.reactnative.androidsdk.FBSDKPackage;
-import com.facebook.appevents.AppEventsLogger;
-...
-
-public class MainApplication extends Application implements ReactApplication {
-
-  private static CallbackManager mCallbackManager = CallbackManager.Factory.create();
-
-  protected static CallbackManager getCallbackManager() {
-    return mCallbackManager;
-  }
-    //...
-```
+Go to `MainApplication.java` under `app/src/main/java/com/<project name>/` to complete setup.
 
 Register SDK package in method `getPackages()`.
 
 ```java
+import com.facebook.reactnative.androidsdk.FBSDKPackage;
+
+// ...
+
 private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
     public boolean getUseDeveloperSupport() {
@@ -92,27 +75,10 @@ private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
-          new FBSDKPackage(mCallbackManager)
+          new FBSDKPackage()
       );
     }
 };
-```
-
-In `MainActivity.java`
-
-Override `onActivityResult()` method
-
-```java
-import android.content.Intent;
-
-public class MainActivity extends ReactActivity {
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        MainApplication.getCallbackManager().onActivityResult(requestCode, resultCode, data);
-    }
-    //...
 ```
 
 Also you need to add in your `settings.gradle`:

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBActivityEventListener.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBActivityEventListener.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.facebook.reactnative.androidsdk;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import com.facebook.CallbackManager;
+import com.facebook.react.bridge.BaseActivityEventListener;
+
+/* package */ class FBActivityEventListener extends BaseActivityEventListener {
+  private CallbackManager mCallbackManager = CallbackManager.Factory.create();
+
+  @Override
+  public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
+    mCallbackManager.onActivityResult(requestCode, resultCode, data);
+  }
+
+  public CallbackManager getCallbackManager() {
+    return mCallbackManager;
+  }
+}

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBGameRequestDialogModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBGameRequestDialogModule.java
@@ -20,7 +20,6 @@
 
 package com.facebook.reactnative.androidsdk;
 
-import com.facebook.CallbackManager;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -34,7 +33,7 @@ import com.facebook.share.widget.GameRequestDialog;
  * Provides functionality to send requests in games.
  * See https://developers.facebook.com/docs/games/requests
  */
-public class FBGameRequestDialogModule extends FBSDKDialogBaseJavaModule {
+public class FBGameRequestDialogModule extends FBSDKCallbackManagerBaseJavaModule {
 
     private class GameRequestDialogCallback extends ReactNativeFacebookSDKCallback<GameRequestDialog.Result> {
 
@@ -54,8 +53,8 @@ public class FBGameRequestDialogModule extends FBSDKDialogBaseJavaModule {
         }
     }
 
-    public FBGameRequestDialogModule(ReactApplicationContext reactContext, CallbackManager callbackManager) {
-        super(reactContext, callbackManager);
+    public FBGameRequestDialogModule(ReactApplicationContext reactContext) {
+        super(reactContext);
     }
 
     @Override

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginButtonManager.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginButtonManager.java
@@ -22,7 +22,6 @@ package com.facebook.reactnative.androidsdk;
 
 import androidx.annotation.Nullable;
 
-import com.facebook.CallbackManager;
 import com.facebook.login.DefaultAudience;
 import com.facebook.login.LoginBehavior;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -36,10 +35,10 @@ public class FBLoginButtonManager extends SimpleViewManager<RCTLoginButton> {
 
     public static final String REACT_CLASS = "RCTFBLoginButton";
 
-    private CallbackManager mCallbackManager;
+    private FBActivityEventListener mActivityEventListener = new FBActivityEventListener();
 
-    public FBLoginButtonManager(ReactApplicationContext reactApplicationContext, CallbackManager callbackManager) {
-        mCallbackManager = callbackManager;
+    public FBLoginButtonManager(ReactApplicationContext reactApplicationContext) {
+        reactApplicationContext.addActivityEventListener(mActivityEventListener);
     }
 
     @Override
@@ -49,7 +48,7 @@ public class FBLoginButtonManager extends SimpleViewManager<RCTLoginButton> {
 
     @Override
     public RCTLoginButton createViewInstance(ThemedReactContext context) {
-        return new RCTLoginButton(context, mCallbackManager);
+        return new RCTLoginButton(context, mActivityEventListener.getCallbackManager());
 
     }
 

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
@@ -23,7 +23,6 @@ package com.facebook.reactnative.androidsdk;
 import android.app.Activity;
 
 import com.facebook.AccessToken;
-import com.facebook.CallbackManager;
 import com.facebook.login.DefaultAudience;
 import com.facebook.login.LoginBehavior;
 import com.facebook.login.LoginManager;
@@ -32,7 +31,6 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableArray;
@@ -43,7 +41,7 @@ import java.util.Set;
 /**
  * This is a {@link NativeModule} that allows JS to use LoginManager of Facebook Android SDK.
  */
-public class FBLoginManagerModule extends ReactContextBaseJavaModule {
+public class FBLoginManagerModule extends FBSDKCallbackManagerBaseJavaModule {
 
     private class LoginManagerCallback extends ReactNativeFacebookSDKCallback<LoginResult> {
 
@@ -68,11 +66,8 @@ public class FBLoginManagerModule extends ReactContextBaseJavaModule {
         }
     }
 
-    private CallbackManager mCallbackManager;
-
-    public FBLoginManagerModule(ReactApplicationContext reactContext, CallbackManager callbackManager) {
+    public FBLoginManagerModule(ReactApplicationContext reactContext) {
         super(reactContext);
-        mCallbackManager = callbackManager;
     }
 
     @Override
@@ -139,7 +134,7 @@ public class FBLoginManagerModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void logInWithPermissions(ReadableArray permissions, final Promise promise) {
         final LoginManager loginManager = LoginManager.getInstance();
-        loginManager.registerCallback(mCallbackManager, new LoginManagerCallback(promise));
+        loginManager.registerCallback(getCallbackManager(), new LoginManagerCallback(promise));
         Activity activity = getCurrentActivity();
         if (activity != null) {
             loginManager.logIn(activity,

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBMessageDialogModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBMessageDialogModule.java
@@ -20,10 +20,6 @@
 
 package com.facebook.reactnative.androidsdk;
 
-import android.content.Intent;
-import android.util.Log;
-
-import com.facebook.CallbackManager;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -36,7 +32,7 @@ import com.facebook.share.widget.MessageDialog;
 /**
  * Provides functionality to send content via the Facebook Message Dialog
  */
-public class FBMessageDialogModule extends FBSDKDialogBaseJavaModule {
+public class FBMessageDialogModule extends FBSDKCallbackManagerBaseJavaModule {
 
     private class MessageDialogCallback extends ReactNativeFacebookSDKCallback<MessageDialog.Result> {
 
@@ -57,8 +53,8 @@ public class FBMessageDialogModule extends FBSDKDialogBaseJavaModule {
 
     private boolean mShouldFailOnDataError;
 
-    public FBMessageDialogModule(ReactApplicationContext reactContext, CallbackManager callbackManager) {
-        super(reactContext, callbackManager);
+    public FBMessageDialogModule(ReactApplicationContext reactContext) {
+        super(reactContext);
     }
 
     @Override

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKCallbackManagerBaseJavaModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKCallbackManagerBaseJavaModule.java
@@ -20,22 +20,21 @@
 
 package com.facebook.reactnative.androidsdk;
 
-import android.content.Intent;
-
 import com.facebook.CallbackManager;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 
-public abstract class FBSDKDialogBaseJavaModule extends ReactContextBaseJavaModule {
+public abstract class FBSDKCallbackManagerBaseJavaModule extends ReactContextBaseJavaModule {
 
-    private CallbackManager mCallbackManager;
+    private FBActivityEventListener mActivityEventListener = new FBActivityEventListener();
 
     protected CallbackManager getCallbackManager()  {
-        return mCallbackManager;
+        return mActivityEventListener.getCallbackManager();
     }
 
-    protected FBSDKDialogBaseJavaModule(ReactApplicationContext reactContext, CallbackManager callbackManager) {
+    protected FBSDKCallbackManagerBaseJavaModule(ReactApplicationContext reactContext) {
         super(reactContext);
-        mCallbackManager = callbackManager;
+
+        reactContext.addActivityEventListener(mActivityEventListener);
     }
 }

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
@@ -20,50 +20,36 @@
 
 package com.facebook.reactnative.androidsdk;
 
-import com.facebook.CallbackManager;
-import com.facebook.internal.InternalSettings;
 import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class FBSDKPackage implements ReactPackage {
-    private CallbackManager mCallbackManager;
-    public FBSDKPackage(CallbackManager callbackManager) {
-        mCallbackManager = callbackManager;
-    }
-
     @Override
     public List<NativeModule> createNativeModules(
             ReactApplicationContext reactContext) {
         return Arrays.<NativeModule>asList(
                 new FBAccessTokenModule(reactContext),
                 new FBAppEventsLoggerModule(reactContext),
-                new FBGameRequestDialogModule(reactContext, mCallbackManager),
+                new FBGameRequestDialogModule(reactContext),
                 new FBGraphRequestModule(reactContext),
-                new FBLoginManagerModule(reactContext, mCallbackManager),
-                new FBMessageDialogModule(reactContext, mCallbackManager),
+                new FBLoginManagerModule(reactContext),
+                new FBMessageDialogModule(reactContext),
                 new FBShareAPIModule(reactContext),
-                new FBShareDialogModule(reactContext, mCallbackManager)
+                new FBShareDialogModule(reactContext)
         );
     }
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList(
-                new FBLoginButtonManager(reactContext, mCallbackManager),
+                new FBLoginButtonManager(reactContext),
                 new FBSendButtonManager(),
                 new FBShareButtonManager()
         );
-    }
-
-    // Deprecated in RN 0.47.0
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
     }
 }

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBShareDialogModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBShareDialogModule.java
@@ -20,10 +20,7 @@
 
 package com.facebook.reactnative.androidsdk;
 
-import com.facebook.CallbackManager;
-import com.facebook.FacebookException;
 import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
@@ -32,7 +29,7 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.share.Sharer;
 import com.facebook.share.widget.ShareDialog;
 
-public class FBShareDialogModule extends FBSDKDialogBaseJavaModule {
+public class FBShareDialogModule extends FBSDKCallbackManagerBaseJavaModule {
 
     private class ShareDialogCallback extends ReactNativeFacebookSDKCallback<Sharer.Result> {
 
@@ -54,8 +51,8 @@ public class FBShareDialogModule extends FBSDKDialogBaseJavaModule {
     private ShareDialog.Mode mShareDialogMode;
     private boolean mShouldFailOnError;
 
-    public FBShareDialogModule(ReactApplicationContext reactContext, CallbackManager callbackManager) {
-        super(reactContext, callbackManager);
+    public FBShareDialogModule(ReactApplicationContext reactContext) {
+        super(reactContext);
     }
 
     @Override

--- a/example/App.js
+++ b/example/App.js
@@ -52,7 +52,11 @@ export default class App extends Component<{}> {
   render() {
     return (
       <View style={styles.container}>
-        <LoginButton />
+        <LoginButton
+          onLoginFinished={(error, data) => {
+            Alert.alert(JSON.stringify(error || data, null, 2));
+          }}
+        />
         <TouchableHighlight onPress={this._shareLinkWithShareDialog}>
           <Text style={styles.shareText}>Share link with ShareDialog</Text>
         </TouchableHighlight>

--- a/example/android/app/src/main/java/com/rnfbsdkexample/MainActivity.java
+++ b/example/android/app/src/main/java/com/rnfbsdkexample/MainActivity.java
@@ -14,10 +14,4 @@ public class MainActivity extends ReactActivity {
     protected String getMainComponentName() {
         return "RNFBSDKExample";
     }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        MainApplication.getCallbackManager().onActivityResult(requestCode, resultCode, data);
-    }
 }

--- a/example/android/app/src/main/java/com/rnfbsdkexample/MainApplication.java
+++ b/example/android/app/src/main/java/com/rnfbsdkexample/MainApplication.java
@@ -2,7 +2,6 @@ package com.rnfbsdkexample;
 
 import android.app.Application;
 
-import com.facebook.CallbackManager;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
@@ -15,12 +14,6 @@ import java.util.List;
 
 public class MainApplication extends Application implements ReactApplication {
 
-  private static CallbackManager mCallbackManager = CallbackManager.Factory.create();
-
-  protected static CallbackManager getCallbackManager() {
-    return mCallbackManager;
-  }
-
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
     public boolean getUseDeveloperSupport() {
@@ -31,7 +24,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
-          new FBSDKPackage(mCallbackManager)
+          new FBSDKPackage()
       );
     }
 


### PR DESCRIPTION
This will simplify the package installation and fix autolinking introduced in RN 0.60

Test Plan:

Tested that the example app works, this doesn't cover all APIs but the changes are abstracted in a way that if it works for one, it should work for all.