### PR TITLE
Only include necessary Android files in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "prettier": "prettier \"./**/*.js\" --write"
   },
   "files": [
-    "android",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/build.gradle",
     "ios",
     "js",
     "LICENSE.txt",


### PR DESCRIPTION
Make sure Android local.properties, build/* and *.iml files are not included in npm package

Taken inspiration from https://github.com/kmagiera/react-native-reanimated/blob/master/package.json#L17

Test Plan:

Run `npm pack` and check output for `*.iml`, `*.property` and `android/build/` files.
