### PR TITLE
Fix sharing callback doesn't get called on Android.

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBGameRequestDialogModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBGameRequestDialogModule.java
@@ -57,8 +57,8 @@ public class FBGameRequestDialogModule extends FBSDKCallbackManagerBaseJavaModul
         }
     }
 
-    public FBGameRequestDialogModule(ReactApplicationContext reactContext) {
-        super(reactContext);
+    public FBGameRequestDialogModule(ReactApplicationContext reactContext,FBActivityEventListener activityEventListener) {
+        super(reactContext, activityEventListener);
     }
 
     @Override

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBGameRequestDialogModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBGameRequestDialogModule.java
@@ -57,7 +57,7 @@ public class FBGameRequestDialogModule extends FBSDKCallbackManagerBaseJavaModul
         }
     }
 
-    public FBGameRequestDialogModule(ReactApplicationContext reactContext,FBActivityEventListener activityEventListener) {
+    public FBGameRequestDialogModule(ReactApplicationContext reactContext, FBActivityEventListener activityEventListener) {
         super(reactContext, activityEventListener);
     }
 

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
@@ -70,8 +70,8 @@ public class FBLoginManagerModule extends FBSDKCallbackManagerBaseJavaModule {
         }
     }
 
-    public FBLoginManagerModule(ReactApplicationContext reactContext) {
-        super(reactContext);
+    public FBLoginManagerModule(ReactApplicationContext reactContext,FBActivityEventListener activityEventListener) {
+        super(reactContext, activityEventListener);
     }
 
     @Override

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
@@ -70,7 +70,7 @@ public class FBLoginManagerModule extends FBSDKCallbackManagerBaseJavaModule {
         }
     }
 
-    public FBLoginManagerModule(ReactApplicationContext reactContext,FBActivityEventListener activityEventListener) {
+    public FBLoginManagerModule(ReactApplicationContext reactContext, FBActivityEventListener activityEventListener) {
         super(reactContext, activityEventListener);
     }
 

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBMessageDialogModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBMessageDialogModule.java
@@ -56,8 +56,8 @@ public class FBMessageDialogModule extends FBSDKCallbackManagerBaseJavaModule {
 
     private boolean mShouldFailOnDataError;
 
-    public FBMessageDialogModule(ReactApplicationContext reactContext) {
-        super(reactContext);
+    public FBMessageDialogModule(ReactApplicationContext reactContext, FBActivityEventListener activityEventListener) {
+        super(reactContext, activityEventListener);
     }
 
     @Override

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKCallbackManagerBaseJavaModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKCallbackManagerBaseJavaModule.java
@@ -26,7 +26,6 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 
 public abstract class FBSDKCallbackManagerBaseJavaModule extends ReactContextBaseJavaModule {
 
-//    private FBActivityEventListener mActivityEventListener = new FBActivityEventListener();
     private FBActivityEventListener mActivityEventListener;
 
     protected CallbackManager getCallbackManager()  {

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKCallbackManagerBaseJavaModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKCallbackManagerBaseJavaModule.java
@@ -26,7 +26,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 
 public abstract class FBSDKCallbackManagerBaseJavaModule extends ReactContextBaseJavaModule {
 
-    private FBActivityEventListener mActivityEventListener;
+    private final FBActivityEventListener mActivityEventListener;
 
     protected CallbackManager getCallbackManager()  {
         return mActivityEventListener.getCallbackManager();
@@ -35,7 +35,7 @@ public abstract class FBSDKCallbackManagerBaseJavaModule extends ReactContextBas
     protected FBSDKCallbackManagerBaseJavaModule(ReactApplicationContext reactContext, FBActivityEventListener activityEventListener) {
         super(reactContext);
 
-        this.mActivityEventListener = activityEventListener;
+        mActivityEventListener = activityEventListener;
         reactContext.addActivityEventListener(mActivityEventListener);
     }
 }

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKCallbackManagerBaseJavaModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKCallbackManagerBaseJavaModule.java
@@ -26,15 +26,17 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 
 public abstract class FBSDKCallbackManagerBaseJavaModule extends ReactContextBaseJavaModule {
 
-    private FBActivityEventListener mActivityEventListener = new FBActivityEventListener();
+//    private FBActivityEventListener mActivityEventListener = new FBActivityEventListener();
+    private FBActivityEventListener mActivityEventListener;
 
     protected CallbackManager getCallbackManager()  {
         return mActivityEventListener.getCallbackManager();
     }
 
-    protected FBSDKCallbackManagerBaseJavaModule(ReactApplicationContext reactContext) {
+    protected FBSDKCallbackManagerBaseJavaModule(ReactApplicationContext reactContext, FBActivityEventListener activityEventListener) {
         super(reactContext);
 
+        this.mActivityEventListener = activityEventListener;
         reactContext.addActivityEventListener(mActivityEventListener);
     }
 }

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
@@ -29,18 +29,21 @@ import java.util.Arrays;
 import java.util.List;
 
 public class FBSDKPackage implements ReactPackage {
+
+    private FBActivityEventListener mActivityEventListener = new FBActivityEventListener();
+
     @Override
     public List<NativeModule> createNativeModules(
             ReactApplicationContext reactContext) {
         return Arrays.<NativeModule>asList(
                 new FBAccessTokenModule(reactContext),
                 new FBAppEventsLoggerModule(reactContext),
-                new FBGameRequestDialogModule(reactContext),
+                new FBGameRequestDialogModule(reactContext, mActivityEventListener),
                 new FBGraphRequestModule(reactContext),
-                new FBLoginManagerModule(reactContext),
-                new FBMessageDialogModule(reactContext),
+                new FBLoginManagerModule(reactContext, mActivityEventListener),
+                new FBMessageDialogModule(reactContext, mActivityEventListener),
                 new FBShareAPIModule(reactContext),
-                new FBShareDialogModule(reactContext)
+                new FBShareDialogModule(reactContext, mActivityEventListener)
         );
     }
 

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBShareDialogModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBShareDialogModule.java
@@ -55,8 +55,8 @@ public class FBShareDialogModule extends FBSDKCallbackManagerBaseJavaModule {
     private ShareDialog.Mode mShareDialogMode;
     private boolean mShouldFailOnError;
 
-    public FBShareDialogModule(ReactApplicationContext reactContext) {
-        super(reactContext);
+    public FBShareDialogModule(ReactApplicationContext reactContext, FBActivityEventListener activityEventListener) {
+        super(reactContext, activityEventListener);
     }
 
     @Override


### PR DESCRIPTION
Fixes #606 

Android ShareDialog callback doesn't work.

Used one `FBActivityEventListener` instance instead of multiple instances.

Previously, we have one `FBActivityEventListener` for each module, and each one has `CallbackManager`.
However, after sharing something, the first `CallbackManager` that got called will run this [static](https://github.com/facebook/facebook-android-sdk/blob/e0080f83249559519ed226ee1c2ceffb08a17596/facebook-core/src/main/java/com/facebook/internal/CallbackManagerImpl.java#L93) [callback](https://github.com/facebook/facebook-android-sdk/blob/e2684a1e474fac878db723a29dfb90576ad7fbe8/facebook-common/src/main/java/com/facebook/share/internal/ShareInternalUtility.java#L155) (because we didn't register the callback to this manager), and make `AppCall` [invalid](https://github.com/facebook/facebook-android-sdk/blob/e2684a1e474fac878db723a29dfb90576ad7fbe8/facebook-common/src/main/java/com/facebook/share/internal/ShareInternalUtility.java#L228).
As a result, the `CallbackManager` for sharing module won't get called, because it has already been [cleared](https://github.com/facebook/facebook-android-sdk/blob/62801a2da892902b1352241d45dcb01092a794d5/facebook-common/src/main/java/com/facebook/internal/AppCall.java#L49)

Test Plan:

Could be tested with the share button on the example app.


Video here.
- [Old Version](https://youtu.be/o1dT8Y7mDmo)
- [New Version](https://youtu.be/Gpiqr5RyU1E)
