### PR TITLE
Return a promise from `updateUserProperties` to handle errors

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
@@ -20,11 +20,16 @@
 
 package com.facebook.reactnative.androidsdk;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.facebook.FacebookRequestError;
+import com.facebook.GraphRequest;
+import com.facebook.GraphResponse;
 import com.facebook.appevents.AppEventsConstants;
 import com.facebook.appevents.AppEventsLogger;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -122,7 +127,7 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
     }
 
     @Override
-    public String getName() {
+    public @NonNull String getName() {
         return NAME;
     }
 
@@ -202,7 +207,7 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
      */
      @ReactMethod
      public void setUserID(final String userID) {
-         mAppEventLogger.setUserID(userID);
+         AppEventsLogger.setUserID(userID);
      }
 
      /**
@@ -213,7 +218,7 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
      @ReactMethod(isBlockingSynchronousMethod = true)
      @Nullable
      public String getUserID() {
-       return mAppEventLogger.getUserID();
+       return AppEventsLogger.getUserID();
      }
 
      /**
@@ -223,11 +228,21 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
       * @param parameters Key-value pairs representing user properties and their values.
       */
      @ReactMethod
-     public void updateUserProperties(ReadableMap parameters) {
-       mAppEventLogger.updateUserProperties(Arguments.toBundle(parameters), null);
+     public void updateUserProperties(ReadableMap parameters, final Promise promise) {
+       AppEventsLogger.updateUserProperties(Arguments.toBundle(parameters), new GraphRequest.Callback() {
+         @Override
+         public void onCompleted(GraphResponse response) {
+           FacebookRequestError error = response.getError();
+           if (error != null) {
+             promise.reject(String.valueOf(error.getErrorCode()), error.getErrorMessage());
+           } else {
+             promise.resolve(null);
+           }
+         }
+       });
      }
 
-    private @Nullable String getNullableString(ReadableMap data, String key) {
+    private static @Nullable String getNullableString(ReadableMap data, String key) {
       return data.hasKey(key) ? data.getString(key) : null;
     }
 

--- a/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
@@ -75,10 +75,17 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getUserID)
   return [FBSDKAppEvents userID];
 }
 
-RCT_EXPORT_METHOD(updateUserProperties:(NSDictionary *)parameters)
+RCT_EXPORT_METHOD(updateUserProperties:(NSDictionary *)parameters
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-  [FBSDKAppEvents updateUserProperties:parameters
-                               handler:nil];
+  [FBSDKAppEvents updateUserProperties:parameters handler:^(FBSDKGraphRequestConnection * _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
+    if (error != nil) {
+      reject(@"FacebookSDK", error.userInfo[FBSDKErrorDeveloperMessageKey], error);
+    } else {
+      resolve(nil);
+    }
+  }];
 }
 
 RCT_EXPORT_METHOD(setUserData:(NSDictionary *)userData)

--- a/js/FBAppEventsLogger.js
+++ b/js/FBAppEventsLogger.js
@@ -130,8 +130,8 @@ module.exports = {
    * Sends a request to update the properties for the current user, set by
    * setUserID. You must call setUserID before making this call.
    */
-  updateUserProperties(parameters: Params) {
-    AppEventsLogger.updateUserProperties(parameters);
+  updateUserProperties(parameters: Params): Promise<void> {
+    return AppEventsLogger.updateUserProperties(parameters);
   },
 
   /**


### PR DESCRIPTION
When passing invalid data to `updateUserProperties` the error is currently swallowed so there is no way to know about it. This makes the method return a promise so we can return errors to JS.

This also does some minor cleanups in FBAppEventsLoggerModule.java

Test Plan:

Call `updateUserProperties` with a null value and check that an error is returned.
