### PR TITLE
Update podspec dependencies version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fbsdk",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Facebook SDK support for React Native apps.",
   "main": "./js/index.js",
   "author": {

--- a/react-native-fbsdk.podspec
+++ b/react-native-fbsdk.podspec
@@ -14,17 +14,17 @@ Pod::Spec.new do |s|
   s.dependency      'React'
 
   s.subspec 'Core' do |ss|
-    ss.dependency     'FBSDKCoreKit', '~> 5.0.0'
+    ss.dependency     'FBSDKCoreKit', '~> 5.6.0'
     ss.source_files = 'ios/RCTFBSDK/core/*.{h,m}'
   end
 
   s.subspec 'Login' do |ss|
-    ss.dependency     'FBSDKLoginKit', '~> 5.0.0'
+    ss.dependency     'FBSDKLoginKit', '~> 5.6.0'
     ss.source_files = 'ios/RCTFBSDK/login/*.{h,m}'
   end
 
   s.subspec 'Share' do |ss|
-    ss.dependency     'FBSDKShareKit', '~> 5.0.0'
+    ss.dependency     'FBSDKShareKit', '~> 5.6.0'
     ss.source_files = 'ios/RCTFBSDK/share/*.{h,m}'
   end
 end


### PR DESCRIPTION
Fixes #644 #646 

**Problem**

- `-canOpenURL: failed for URL: "fbauth2:/" - error: "The operation couldn’t be completed.` on iOS 13

- `logInWithReadPermissions returning isCancelled value always true`

**Solution**
- Update podspec dependencies version from '5.0.0' to '5.6.0'