### PR TITLE
Update README.md with React Native version compatibility explanation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To use this library you need to ensure you match up with the correct version of 
 
 | `react-native-fbsdk` version | Required React Native Version                                                     |
 | ----------------------------------------- | --------------------------------------------------------------------------------- |
-| `>= 1.0.0rc0`                                   | `>= 0.60`                                                                     |
+| `>= 1.0.0`                                   | `>= 0.60`                                                                     |
 | `<= 0.10`                                   | `<= 0.59.x`                                                                         |
 
 ### 1. Install the library

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Functionality is provided through one single npm package so you can use it for b
 
 ## Installation
 
+## React Native Compatibility
+To use this library you need to ensure you match up with the correct version of React Native you are using.
+
+| `react-native-fbsdk` version | Required React Native Version                                                     |
+| ----------------------------------------- | --------------------------------------------------------------------------------- |
+| `>= 1.0.0rc0`                                   | `>= 0.60`                                                                     |
+| `<= 0.10`                                   | `<= 0.59.x`                                                                         |
+
 ### 1. Install the library
 
 using either Yarn:


### PR DESCRIPTION
Update Readme with React Native version table to explain versions of react-native-fbsdk greater than 1.0rc0 require React Native 0.60 or greater.

Test Plan: Non applicable.