### PR TITLE
Chore/introduce safeExtGet to simplify root project property access

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,20 +1,23 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 def DEFAULT_COMPILE_SDK_VERSION             = 28
 def DEFAULT_BUILD_TOOLS_VERSION             = "28.0.3"
 def DEFAULT_MIN_SDK_VERSION                 = 16
 def DEFAULT_TARGET_SDK_VERSION              = 28
 def DEFAULT_FACEBOOK_SDK_VERSION            = "[5.0,6.0["
 
-def FACEBOOK_SDK_VERSION = rootProject.hasProperty('facebookSdkVersion') ? rootProject.facebookSdkVersion : DEFAULT_FACEBOOK_SDK_VERSION
-
+def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', DEFAULT_FACEBOOK_SDK_VERSION)
 android {
-    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
-    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+    compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
+    buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
 
     defaultConfig {
-        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : DEFAULT_MIN_SDK_VERSION
-        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
+        minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
+        targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
     }
     buildTypes {
         release {


### PR DESCRIPTION
As noted on the title, added `safeExtGet` function seen in many other RN library projects so that we can remove some redundant version check code.


Test Plan:

- [x] Example app build passes and runs
