### PR TITLE
update facebook sdks to 5.8.0 for ios

### DIFF
--- a/react-native-fbsdk.podspec
+++ b/react-native-fbsdk.podspec
@@ -14,17 +14,17 @@ Pod::Spec.new do |s|
   s.dependency      'React'
 
   s.subspec 'Core' do |ss|
-    ss.dependency     'FBSDKCoreKit', '~> 5.5'
+    ss.dependency     'FBSDKCoreKit', '~> 5.8'
     ss.source_files = 'ios/RCTFBSDK/core/*.{h,m}'
   end
 
   s.subspec 'Login' do |ss|
-    ss.dependency     'FBSDKLoginKit', '~> 5.5'
+    ss.dependency     'FBSDKLoginKit', '~> 5.8'
     ss.source_files = 'ios/RCTFBSDK/login/*.{h,m}'
   end
 
   s.subspec 'Share' do |ss|
-    ss.dependency     'FBSDKShareKit', '~> 5.5'
+    ss.dependency     'FBSDKShareKit', '~> 5.8'
     ss.source_files = 'ios/RCTFBSDK/share/*.{h,m}'
   end
 end

--- a/react-native-fbsdk.podspec
+++ b/react-native-fbsdk.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license       = package['license']
   s.homepage      = package['homepage']
   s.source        = { :git => 'https://github.com/facebook/react-native-fbsdk.git', :tag => "v#{package['version']}" }
-  s.platform      = :ios, '7.0'
+  s.platform      = :ios, '8.0'
   s.dependency      'React'
 
   s.subspec 'Core' do |ss|


### PR DESCRIPTION
Update facebook sdks to latest version `5.8.0` which is already used on android

Test Plan:
We use this change in our app:
- [x] pod install and ios build still works
- [x] facebook login works
