### PR TITLE
Add method to listen for changes to the access token

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAccessTokenModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAccessTokenModule.java
@@ -22,6 +22,7 @@
 package com.facebook.reactnative.androidsdk;
 
 import com.facebook.AccessToken;
+import com.facebook.AccessTokenTracker;
 import com.facebook.FacebookException;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.NativeModule;
@@ -31,6 +32,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 /**
  * This is a {@link NativeModule} that allows JS to use AcessToken in Facebook Android SDK.
@@ -39,9 +41,21 @@ import com.facebook.react.module.annotations.ReactModule;
 public class FBAccessTokenModule extends ReactContextBaseJavaModule {
 
     public static final String NAME = "FBAccessToken";
+    public static final String CHANGE_EVENT_NAME = "fbsdk.accessTokenDidChange";
+
+    private final ReactApplicationContext mReactContext;
+    private final AccessTokenTracker accessTokenTracker = new AccessTokenTracker() {
+        @Override
+        protected void onCurrentAccessTokenChanged(AccessToken oldAccessToken, AccessToken currentAccessToken) {
+            mReactContext
+                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                    .emit(CHANGE_EVENT_NAME, currentAccessToken == null ? null : Utility.accessTokenToReactMap(currentAccessToken));
+        }
+    };
 
     public FBAccessTokenModule(ReactApplicationContext reactContext) {
         super(reactContext);
+        mReactContext = reactContext;
     }
 
     public String getName() {

--- a/ios/RCTFBSDK/core/RCTFBSDKAccessToken.h
+++ b/ios/RCTFBSDK/core/RCTFBSDKAccessToken.h
@@ -16,9 +16,9 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 
-@interface RCTFBSDKAccessToken : NSObject <RCTBridgeModule>
+@interface RCTFBSDKAccessToken : RCTEventEmitter
 @end

--- a/ios/RCTFBSDK/core/RCTFBSDKAccessToken.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKAccessToken.m
@@ -22,7 +22,11 @@
 
 #import "RCTConvert+FBSDKAccessToken.h"
 
-@implementation RCTFBSDKAccessToken
+static NSString *const kFBSDKAccessTokenDidChangeEvent = @"fbsdk.accessTokenDidChange";
+
+@implementation RCTFBSDKAccessToken {
+  BOOL _isObserving;
+}
 
 RCT_EXPORT_MODULE(FBAccessToken);
 
@@ -54,6 +58,38 @@ RCT_EXPORT_METHOD(refreshCurrentAccessTokenAsync:(RCTPromiseResolveBlock)resolve
       resolve(result);
     }
   }];
+}
+
+#pragma mark - Event Methods
+
+- (NSArray *)supportedEvents
+{
+  return @[kFBSDKAccessTokenDidChangeEvent];
+}
+
+- (void)startObserving
+{
+  _isObserving = YES;
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(accessTokenDidChange:)
+                                               name:FBSDKAccessTokenDidChangeNotification
+                                             object:nil];
+}
+
+- (void)stopObserving
+{
+  _isObserving = NO;
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:FBSDKAccessTokenDidChangeNotification
+                                                object:nil];
+}
+
+- (void)accessTokenDidChange:(NSNotification*)notification
+{
+  if ([notification.name isEqualToString:FBSDKAccessTokenDidChangeNotification] && _isObserving) {
+    NSDictionary *body = RCTBuildAccessTokenDict([FBSDKAccessToken currentAccessToken]);
+    [self sendEventWithName:kFBSDKAccessTokenDidChangeEvent body:body ?: [NSNull null]];
+  }
 }
 
 #pragma mark - Helper Functions

--- a/js/FBAccessToken.js
+++ b/js/FBAccessToken.js
@@ -25,6 +25,9 @@
 
 const AccessToken = require('react-native').NativeModules.FBAccessToken;
 
+const NativeEventEmitter = require('react-native').NativeEventEmitter;
+const eventEmitter = new NativeEventEmitter(AccessToken);
+
 type AccessTokenMap = {
   accessToken: string,
   permissions: Array<string>,
@@ -138,6 +141,26 @@ class FBAccessToken {
    */
   static refreshCurrentAccessTokenAsync(): Promise<any> {
     return AccessToken.refreshCurrentAccessTokenAsync();
+  }
+
+  /**
+   * Adds a listener for when the access token changes. Returns a functions which removes the
+   * listener when called.
+   */
+  static addListener(
+    listener: (accessToken: ?FBAccessToken) => void,
+  ): () => void {
+    const subscription = eventEmitter.addListener(
+      'fbsdk.accessTokenDidChange',
+      (tokenMap: AccessTokenMap) => {
+        if (tokenMap) {
+          listener(new FBAccessToken(tokenMap));
+        } else {
+          listener(null);
+        }
+      },
+    );
+    return () => subscription.remove();
   }
 
   /**


### PR DESCRIPTION
This PR adds a method which allows you to monitor the access token for changes. This enable you to have a hook which accurately represents the Facebook Access Token which will update when the user logs in or out.

It is implemented using the notifications (iOS) and tracker (Android) which the natvie Facebook SDKs provide.

**Test Plan:**

Tested on both platforms using the following hook code:

```typescript
const useFacebookToken = () => {
  const [accessToken, setAccessToken] = React.useState<FBSDK.AccessToken>();

  React.useEffect(() => {
    FBSDK.AccessToken.getCurrentAccessToken().then(setAccessToken);

    return FBSDK.AccessToken.addListener(setAccessToken);
  }, []);

  return accessToken;
};
```
