### PR TITLE
Keep Facebook SDK at 5.8

### DIFF
--- a/react-native-fbsdk.podspec
+++ b/react-native-fbsdk.podspec
@@ -14,17 +14,17 @@ Pod::Spec.new do |s|
   s.dependency      'React'
 
   s.subspec 'Core' do |ss|
-    ss.dependency     'FBSDKCoreKit', '~> 5.8'
+    ss.dependency     'FBSDKCoreKit', '= 5.8'
     ss.source_files = 'ios/RCTFBSDK/core/*.{h,m}'
   end
 
   s.subspec 'Login' do |ss|
-    ss.dependency     'FBSDKLoginKit', '~> 5.8'
+    ss.dependency     'FBSDKLoginKit', '= 5.8'
     ss.source_files = 'ios/RCTFBSDK/login/*.{h,m}'
   end
 
   s.subspec 'Share' do |ss|
-    ss.dependency     'FBSDKShareKit', '~> 5.8'
+    ss.dependency     'FBSDKShareKit', '= 5.8'
     ss.source_files = 'ios/RCTFBSDK/share/*.{h,m}'
   end
 end


### PR DESCRIPTION
This PR aims to keep Facebook SDK at 5.8.0. Currently if we try to `pod install` or `pod update` the project, it will automatically install latest version of FBSDKCoreKit (5.10.0), which leads to issue #667 . By keeping it at exactly 5.8.0, that issue is solved.

Test Plan:

Just use the updated `react-native-fbsdk.podspec` file, and don't forget to `pod update`. Tested on RN 0.61.4 and 0.60.1.