### PR TITLE
Fix react native peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   ],
   "dependencies": {},
   "peerDependencies": {
-    "react-native": ">=0.60.0"
+    "react-native": "*"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   ],
   "dependencies": {},
   "peerDependencies": {
-    "react-native": "*"
+    "react-native": ">=0.59.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",


### PR DESCRIPTION
I'm using `react-native: 0.59.10` and when I install I see this `warning: react-native-fbsdk@1.1.2 has incorrect peer dependency "react-native@>=0.60.0"`

Test Plan:

When install the package this warning should not appear

