### PR TITLE
Update Android Gradle plugin to 3.6.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,16 +3,16 @@ def safeExtGet(prop, fallback) {
 }
 
 buildscript {
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
     if (project == rootProject) {
-        // The Android Gradle plugin is only required when opening the android folder stand-alone.
-        // This avoids unnecessary downloads and potential conflicts when the library is included as a
-        // module dependency in an application project.
         repositories {
             google()
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.5.2'
+            classpath 'com.android.tools.build:gradle:3.6.3'
         }
     }
 }


### PR DESCRIPTION
Android Studio 3.6.3 is now available:

https://androidstudio.googleblog.com/2020/04/android-studio-363-available.html