### PR TITLE
autoInitialize added to Utility

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
@@ -25,7 +25,6 @@ import android.net.Uri;
 import com.facebook.AccessToken;
 import com.facebook.AccessTokenSource;
 import com.facebook.FacebookSdk;
-import com.facebook.appevents.AppEventsLogger;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
@@ -333,9 +332,8 @@ public final class Utility {
         return array;
     }
 
-    public static void autoInitialize(Context ctx) {
+    public static void autoInitialize() {
         FacebookSdk.setAutoInitEnabled(true);
         FacebookSdk.fullyInitialize();
-        AppEventsLogger.activateApp(ctx);
     }
 }

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
@@ -24,6 +24,7 @@ import android.net.Uri;
 
 import com.facebook.AccessToken;
 import com.facebook.AccessTokenSource;
+import com.facebook.FacebookSdk;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
@@ -329,5 +330,10 @@ public final class Utility {
             array[i++] = e;
         }
         return array;
+    }
+
+    public static void autoInitialize() {
+        FacebookSdk.setAutoInitEnabled(true);
+        FacebookSdk.fullyInitialize();
     }
 }

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
@@ -25,6 +25,7 @@ import android.net.Uri;
 import com.facebook.AccessToken;
 import com.facebook.AccessTokenSource;
 import com.facebook.FacebookSdk;
+import com.facebook.appevents.AppEventsLogger;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
@@ -332,8 +333,9 @@ public final class Utility {
         return array;
     }
 
-    public static void autoInitialize() {
+    public static void autoInitialize(Context ctx) {
         FacebookSdk.setAutoInitEnabled(true);
         FacebookSdk.fullyInitialize();
+        AppEventsLogger.activateApp(ctx);
     }
 }


### PR DESCRIPTION
As we can simply call `[FBSDKSettings setAutoInitEnabled: YES ];` for iOS, it would be nice to have an easy way to run this initialisation for Android too. So I added the code to `Utility.java` to run it as `autoInitialize()`.
As suggested [here](https://developers.facebook.com/docs/app-events/gdpr-compliance/).