### PR TITLE
Use locale insensitive toUpperCase and toLowerCase 

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
@@ -33,6 +33,7 @@ import com.facebook.react.module.annotations.ReactModule;
 
 import java.math.BigDecimal;
 import java.util.Currency;
+import java.util.Locale;
 
 /**
  * <p>
@@ -133,7 +134,7 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     public void setFlushBehavior(String flushBehavior) {
-        AppEventsLogger.setFlushBehavior(AppEventsLogger.FlushBehavior.valueOf(flushBehavior.toUpperCase()));
+        AppEventsLogger.setFlushBehavior(AppEventsLogger.FlushBehavior.valueOf(flushBehavior.toUpperCase(Locale.ROOT)));
     }
 
     /**

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginButtonManager.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginButtonManager.java
@@ -30,6 +30,8 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 
+import java.util.Locale;
+
 
 public class FBLoginButtonManager extends SimpleViewManager<RCTLoginButton> {
 
@@ -54,12 +56,12 @@ public class FBLoginButtonManager extends SimpleViewManager<RCTLoginButton> {
 
     @ReactProp(name = "loginBehaviorAndroid")
     public void setLoginBehavior(RCTLoginButton loginButton, @Nullable String loginBehavior) {
-        loginButton.setLoginBehavior(LoginBehavior.valueOf(loginBehavior.toUpperCase()));
+        loginButton.setLoginBehavior(LoginBehavior.valueOf(loginBehavior.toUpperCase(Locale.ROOT)));
     }
 
     @ReactProp(name = "defaultAudience")
     public void setDefaultAudience(RCTLoginButton loginButton, @Nullable String defaultAudience) {
-        loginButton.setDefaultAudience(DefaultAudience.valueOf(defaultAudience.toUpperCase()));
+        loginButton.setDefaultAudience(DefaultAudience.valueOf(defaultAudience.toUpperCase(Locale.ROOT)));
     }
 
     @ReactProp(name = "permissions")

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
@@ -37,6 +37,7 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.module.annotations.ReactModule;
 
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -85,7 +86,7 @@ public class FBLoginManagerModule extends FBSDKCallbackManagerBaseJavaModule {
      */
     @ReactMethod
     public void getLoginBehavior(Promise promise) {
-        promise.resolve(LoginManager.getInstance().getLoginBehavior().name().toLowerCase());
+        promise.resolve(LoginManager.getInstance().getLoginBehavior().name().toLowerCase(Locale.ROOT));
     }
 
     /**
@@ -96,7 +97,7 @@ public class FBLoginManagerModule extends FBSDKCallbackManagerBaseJavaModule {
      */
     @ReactMethod
     public void setLoginBehavior(String loginBehaviorString) {
-        LoginBehavior loginBehavior = LoginBehavior.valueOf(loginBehaviorString.toUpperCase());
+        LoginBehavior loginBehavior = LoginBehavior.valueOf(loginBehaviorString.toUpperCase(Locale.ROOT));
         LoginManager.getInstance().setLoginBehavior(loginBehavior);
     }
 
@@ -106,7 +107,7 @@ public class FBLoginManagerModule extends FBSDKCallbackManagerBaseJavaModule {
      */
     @ReactMethod
     public void getDefaultAudience(Promise promise) {
-        promise.resolve(LoginManager.getInstance().getDefaultAudience().name().toLowerCase());
+        promise.resolve(LoginManager.getInstance().getDefaultAudience().name().toLowerCase(Locale.ROOT));
     }
 
     /**
@@ -116,7 +117,7 @@ public class FBLoginManagerModule extends FBSDKCallbackManagerBaseJavaModule {
      */
     @ReactMethod
     public void setDefaultAudience(String defaultAudienceString) {
-        DefaultAudience defaultAudience = DefaultAudience.valueOf(defaultAudienceString.toUpperCase());
+        DefaultAudience defaultAudience = DefaultAudience.valueOf(defaultAudienceString.toUpperCase(Locale.ROOT));
         LoginManager.getInstance().setDefaultAudience(defaultAudience);
     }
 

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBShareDialogModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBShareDialogModule.java
@@ -30,6 +30,8 @@ import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.share.Sharer;
 import com.facebook.share.widget.ShareDialog;
 
+import java.util.Locale;
+
 @ReactModule(name = FBShareDialogModule.NAME)
 public class FBShareDialogModule extends FBSDKCallbackManagerBaseJavaModule {
 
@@ -96,7 +98,7 @@ public class FBShareDialogModule extends FBSDKCallbackManagerBaseJavaModule {
 
     @ReactMethod
     public void setMode(String mode) {
-        mShareDialogMode = ShareDialog.Mode.valueOf(mode.toUpperCase());
+        mShareDialogMode = ShareDialog.Mode.valueOf(mode.toUpperCase(Locale.ROOT));
     }
 
     @ReactMethod

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
@@ -47,6 +47,7 @@ import com.facebook.share.model.ShareVideoContent;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import androidx.annotation.Nullable;
@@ -145,12 +146,12 @@ public final class Utility {
         String actionType = getValueOrNull(gameRequestContentMap, "actionType");
         if (actionType != null) {
             gameRequestContentBuilder.setActionType(
-                    GameRequestContent.ActionType.valueOf(actionType.toUpperCase()));
+                    GameRequestContent.ActionType.valueOf(actionType.toUpperCase(Locale.ROOT)));
         }
         String filters = getValueOrNull(gameRequestContentMap, "filters");
         if (filters != null) {
             gameRequestContentBuilder.setFilters(
-                    GameRequestContent.Filters.valueOf(filters.toUpperCase()));
+                    GameRequestContent.Filters.valueOf(filters.toUpperCase(Locale.ROOT)));
         }
         gameRequestContentBuilder.setMessage(gameRequestContentMap.getString("message"));
         if (gameRequestContentMap.hasKey("recipients")) {


### PR DESCRIPTION
Fixes # #728

Test Plan:

Before this PR, if you run following example, 

```
export default class App extends Component<{}> {
  _login = async () => {
    try {
      LoginManager.setLoginBehavior('native_with_fallback');
      await LoginManager.logInWithPermissions(['email']);
    } catch (e) {
      Alert.alert(JSON.stringify(e));
    }
  };

  render() {
    return (
      <View style={styles.container}>
        <TouchableHighlight onPress={this._login}>
          <Text>Login</Text>
        </TouchableHighlight>
      </View>
    );
  }
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
  },
});
```

you could see the following error on Android Debug Console.

```
E/unknown:ReactNative: Exception in native call
    java.lang.IllegalArgumentException: No enum constant com.facebook.login.LoginBehavior.NATİVE_WİTH_FALLBACK
        at java.lang.Enum.valueOf(Enum.java:258)
        at com.facebook.login.LoginBehavior.valueOf(LoginBehavior.java:26)
        at com.facebook.reactnative.androidsdk.FBLoginManagerModule.setLoginBehavior(FBLoginManagerModule.java:100)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
        at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:158)
        at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
        at android.os.Handler.handleCallback(Handler.java:873)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:29)
        at android.os.Looper.loop(Looper.java:193)
        at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:232)
        at java.lang.Thread.run(Thread.java:764)
```

And this leads crash on release mode. I've tested that app works fine after this pr.