### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ Before you can run the project, follow the [Getting Started Guide](https://devel
 
 #### 3.2 iOS
 
-Follow ***steps 3 and 4*** in the [Getting Started Guide](https://developers.facebook.com/docs/ios/getting-started/) for Facebook SDK for iOS.
+Follow ***steps 3 and 4*** in the [Getting Started Guide](https://developers.facebook.com/docs/ios/getting-started/?sdk=cocoapods) for Facebook SDK for iOS.
 
-**If you're not using cocoapods already** you can also follow step 2 to set it up.
+**If you're not using cocoapods already** you can also follow step 1.1 to set it up.
 
 **If you're using React Native's RCTLinkingManager**
 


### PR DESCRIPTION
https://developers.facebook.com/docs/ios/getting-started is confusing for us because:

>In the following list, select the appropriate SDK for the language you will use in this app. If your app uses Swift, select SDK: Cocoapods. If your app uses Objective-C, select SDK: FB SDK

None of these are true in our case, but we **do** want to have _SDK: Cocoapods_ pre-selected.

Further, 1.1 clarifies to only go as far as

> 1. Install Cocoapods.

**not** further to install pod 'FBSDKCoreKit/Swift'.