### PR TITLE
Avoid app crashing on access token change

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAccessTokenModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAccessTokenModule.java
@@ -61,9 +61,15 @@ public class FBAccessTokenModule extends ReactContextBaseJavaModule {
         accessTokenTracker = new AccessTokenTracker() {
             @Override
             protected void onCurrentAccessTokenChanged(AccessToken oldAccessToken, AccessToken currentAccessToken) {
-                mReactContext
-                        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                        .emit(CHANGE_EVENT_NAME, currentAccessToken == null ? null : Utility.accessTokenToReactMap(currentAccessToken));
+                try {
+                    mReactContext
+                            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                            .emit(CHANGE_EVENT_NAME, currentAccessToken == null ? null : Utility.accessTokenToReactMap(currentAccessToken));
+                } catch (RuntimeException ex) {
+                    // It is possible that the react context might not have initialized when this
+                    // event is broadcasted from AccessTokenTracker, so rather than crashing with
+                    // an error message, ignoring the change
+                }
             }
         };
 


### PR DESCRIPTION
The access token change event is broadcasted from AccessTokenTracker
during app start, even before the react-native has fully initialized.
This results in a RuntimeException while trying to retrieve the
JSModule from context. This is just a safe escape hatch to avoid app
crashing. A more robust solution might be deferring the change event
after the react-native initializes.

Fixes #726
