### PR TITLE
Update podspec for tvOS

### DIFF
--- a/react-native-fbsdk.podspec
+++ b/react-native-fbsdk.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license       = package['license']
   s.homepage      = package['homepage']
   s.source        = { :git => 'https://github.com/facebook/react-native-fbsdk.git', :tag => "v#{package['version']}" }
-  s.platform      = :ios, '8.0'
+  s.platforms     = { :ios => "9.0", :tvos => "9.2" }
   s.dependency      'React'
 
   s.subspec 'Core' do |ss|


### PR DESCRIPTION
The native FBSSDK has support for tvOS but in the podspec for this repo it was not added. We use the SDK in out Apps and needed this support. So I added it an hope that it can get merged into the library.