### PR TITLE
Add getters for anonymousID, attributionID and advertiserID

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
@@ -24,6 +24,7 @@ import androidx.annotation.Nullable;
 
 import com.facebook.appevents.AppEventsConstants;
 import com.facebook.appevents.AppEventsLogger;
+import com.facebook.internal.AttributionIdentifiers;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -109,6 +110,7 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
     public static final String NAME = "FBAppEventsLogger";
 
     private AppEventsLogger mAppEventLogger;
+    private AttributionIdentifiers mAttributionIdentifiers;
     private ReactApplicationContext mReactContext;
 
     public FBAppEventsLoggerModule(ReactApplicationContext reactContext) {
@@ -119,6 +121,7 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
     @Override
     public void initialize() {
         mAppEventLogger = AppEventsLogger.newLogger(mReactContext);
+        mAttributionIdentifiers = AttributionIdentifiers.getAttributionIdentifiers(mReactContext);
     }
 
     @Override
@@ -214,6 +217,40 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
      @Nullable
      public String getUserID() {
        return mAppEventLogger.getUserID();
+     }
+
+     /**
+      * Each app/device pair gets an GUID that is sent back with App Events and persisted with this
+      * app/device pair.
+      *
+      * @return The GUID for this app/device pair.
+      */
+     @ReactMethod(isBlockingSynchronousMethod = true)
+     @Nullable
+     public String getAnonymousID() {
+       return mAppEventLogger.getAnonymousAppDeviceGUID(mReactContext);
+     }
+
+     /**
+      * Returns the advertiser id or null if not set
+      *
+      * @return The advertiser ID or null
+      */
+     @ReactMethod(isBlockingSynchronousMethod = true)
+     @Nullable
+     public String getAdvertiserID() {
+       return mAttributionIdentifiers.getAndroidAdvertiserId();
+     }
+
+     /**
+      * Returns the attribution id or null if not set
+      *
+      * @return The attribution ID or null
+      */
+     @ReactMethod(isBlockingSynchronousMethod = true)
+     @Nullable
+     public String getAttributionID() {
+       return mAttributionIdentifiers.getAttributionId();
      }
 
      /**

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
@@ -26,6 +26,7 @@ import com.facebook.appevents.AppEventsConstants;
 import com.facebook.appevents.AppEventsLogger;
 import com.facebook.internal.AttributionIdentifiers;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -225,32 +226,37 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
       *
       * @return The GUID for this app/device pair.
       */
-     @ReactMethod(isBlockingSynchronousMethod = true)
-     @Nullable
-     public String getAnonymousID() {
-       return mAppEventLogger.getAnonymousAppDeviceGUID(mReactContext);
+     @ReactMethod
+     public void getAnonymousID(Promise promise) {
+       try {
+         promise.resolve(mAppEventLogger.getAnonymousAppDeviceGUID(mReactContext));
+       } catch (Exception e) {
+         promise.reject("E_ANONYMOUS_ID_ERROR", "Can not get anonymousID", e);
+       }
      }
 
      /**
       * Returns the advertiser id or null if not set
-      *
-      * @return The advertiser ID or null
       */
-     @ReactMethod(isBlockingSynchronousMethod = true)
-     @Nullable
-     public String getAdvertiserID() {
-       return mAttributionIdentifiers.getAndroidAdvertiserId();
+     @ReactMethod
+     public void getAdvertiserID(Promise promise) {
+       try {
+         promise.resolve(mAttributionIdentifiers.getAndroidAdvertiserId());
+       } catch (Exception e) {
+         promise.reject("E_ADVERTISER_ID_ERROR", "Can not get advertiserID", e);
+       }
      }
 
      /**
       * Returns the attribution id or null if not set
-      *
-      * @return The attribution ID or null
       */
-     @ReactMethod(isBlockingSynchronousMethod = true)
-     @Nullable
-     public String getAttributionID() {
-       return mAttributionIdentifiers.getAttributionId();
+     @ReactMethod
+     public void getAttributionID(Promise promise) {
+       try {
+         promise.resolve(mAttributionIdentifiers.getAttributionId());
+       } catch (Exception e) {
+         promise.reject("E_ATTRIBUTION_ID_ERROR", "Can not get attributionID", e);
+       }
      }
 
      /**

--- a/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
@@ -21,6 +21,7 @@
 #import <React/RCTUtils.h>
 
 #import "RCTConvert+FBSDKAccessToken.h"
+#import "FBSDKCoreKit/FBSDKAppEventsUtility.h"
 
 @implementation RCTConvert (RCTFBSDKAppEvents)
 
@@ -79,6 +80,16 @@ RCT_EXPORT_METHOD(setUserID:(NSString *)userID)
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getUserID)
 {
   return [FBSDKAppEvents userID];
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getAnonymousID)
+{
+  return [FBSDKAppEvents anonymousID];
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getAdvertiserID)
+{
+  return [FBSDKAppEventsUtility advertiserID];
 }
 
 RCT_EXPORT_METHOD(updateUserProperties:(NSDictionary *)parameters)

--- a/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
@@ -82,14 +82,28 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getUserID)
   return [FBSDKAppEvents userID];
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getAnonymousID)
+RCT_EXPORT_METHOD(getAnonymousID:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-  return [FBSDKAppEvents anonymousID];
+  @try {
+    NSString *anonymousID = [FBSDKAppEvents anonymousID];
+    resolve(anonymousID);
+  }
+  @catch (NSError *error) {
+    reject(@"E_ANONYMOUS_ID_ERROR", @"Can not get anonymousID", error);
+  }
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getAdvertiserID)
+RCT_EXPORT_METHOD(getAdvertiserID:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-  return [FBSDKAppEventsUtility advertiserID];
+  @try {
+    NSString *advertiserID = [FBSDKAppEventsUtility advertiserID];
+    resolve(advertiserID);
+  }
+  @catch (NSError *error) {
+    reject(@"E_ADVERTISER_ID_ERROR", @"Can not get advertiserID", error);
+  }
 }
 
 RCT_EXPORT_METHOD(updateUserProperties:(NSDictionary *)parameters)

--- a/src/FBAppEventsLogger.js
+++ b/src/FBAppEventsLogger.js
@@ -23,6 +23,7 @@
 'use strict';
 
 const AppEventsLogger = require('react-native').NativeModules.FBAppEventsLogger;
+const {Platform} = require('react-native');
 /**
  * Controls when an AppEventsLogger sends log events to the server
  */
@@ -124,6 +125,31 @@ module.exports = {
    */
   async getUserID(): Promise<?string> {
     return await AppEventsLogger.getUserID();
+  },
+
+  /**
+   * Returns anonymous id or null if not set
+   */
+  async getAnonymousID(): Promise<?string> {
+    return await AppEventsLogger.getAnonymousID();
+  },
+
+  /**
+   * Returns advertiser id or null if not set
+   */
+  async getAdvertiserID(): Promise<?string> {
+    return await AppEventsLogger.getAdvertiserID();
+  },
+
+  /**
+   * Returns advertiser id or null if not set.
+   * @platform android
+   */
+  async getAttributionID(): Promise<?string> {
+    if (Platform.OS === 'ios') {
+      return null;
+    }
+    return await AppEventsLogger.getAttributionID();
   },
 
   /**


### PR DESCRIPTION
Fixes #599 
- Added access to anonymousID, attributionID and advertiserID from native sdks.

Test Plan:

Integrate the sdk to any project and try to get this values:
```js
import {AppEventsLogger} from 'react-native-fbsdk';
...
    AppEventsLogger.getAnonymousID()
      .then(anonymousID => {
        console.log('anonymousID fbsdk', anonymousID);
      })
      .catch(e => {
        console.error(e);
      });
    AppEventsLogger.getAdvertiserID()
      .then(advertiserID => {
        console.log('advertiserID fbsdk', advertiserID);
      })
      .catch(e => {
        console.error(e);
      });
    AppEventsLogger.getAttributionID()
      .then(attributionID => {
        console.log('attributionID fbsdk', attributionID);
      })
      .catch(e => {
        console.error(e);
      });
...
```
Note that `attributionID` will be empty on emulators.