### PR TITLE
Implement fetch deferred app link

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,5 +53,4 @@ dependencies {
     implementation "com.facebook.android:facebook-core:${FACEBOOK_SDK_VERSION}"
     implementation "com.facebook.android:facebook-login:${FACEBOOK_SDK_VERSION}"
     implementation "com.facebook.android:facebook-share:${FACEBOOK_SDK_VERSION}"
-    implementation "com.facebook.android:facebook-applinks:${FACEBOOK_SDK_VERSION}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,4 +53,5 @@ dependencies {
     implementation "com.facebook.android:facebook-core:${FACEBOOK_SDK_VERSION}"
     implementation "com.facebook.android:facebook-login:${FACEBOOK_SDK_VERSION}"
     implementation "com.facebook.android:facebook-share:${FACEBOOK_SDK_VERSION}"
+    implementation "com.facebook.android:facebook-applinks:${FACEBOOK_SDK_VERSION}"
 }

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppLinkModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppLinkModule.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ * <p/>
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ * <p/>
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.facebook.reactnative.androidsdk;
+
+import com.facebook.applinks.AppLinkData;
+import com.facebook.internal.Utility;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.module.annotations.ReactModule;
+
+import org.json.JSONObject;
+
+/**
+ * FBAppLinkModule
+ */
+@ReactModule(name = FBAppLinkModule.NAME)
+public class FBAppLinkModule extends ReactContextBaseJavaModule {
+    public static final String NAME = "FBAppLink";
+
+    private final ReactApplicationContext mReactContext;
+
+    public FBAppLinkModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+        mReactContext = reactContext;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    /**
+     * The completion handler of fetchDeferredAppLinkData.
+     *
+     * @param promise If AppLinkData is found, resolve app link url, otherwise resolve null.
+     */
+    private AppLinkData.CompletionHandler createCompletionHandler(final Promise promise) {
+        return new AppLinkData.CompletionHandler() {
+            @Override
+            public void onDeferredAppLinkDataFetched(AppLinkData appLinkData) {
+                if (appLinkData == null) {
+                    promise.resolve(null);
+                } else {
+                    promise.resolve(appLinkData.getTargetUri().toString());
+                }
+            }
+        };
+    }
+
+    /**
+     * Asynchronously fetches app link information that might have been stored for use after
+     * installation of the app.
+     *
+     * @param promise Used to pass app link to JS on fetch completed using completion handler.
+     */
+    @ReactMethod
+    public void fetchDeferredAppLink(final Promise promise) {
+        try {
+            AppLinkData.fetchDeferredAppLinkData(mReactContext.getApplicationContext(),
+                    createCompletionHandler(promise));
+        } catch (Exception e) {
+            promise.resolve(null);
+            Utility.logd(getName(), "Received error while fetching deferred app link", e);
+        }
+    }
+}

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
@@ -38,6 +38,7 @@ public class FBSDKPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(
                 new FBAccessTokenModule(reactContext),
                 new FBAppEventsLoggerModule(reactContext),
+                new FBAppLinkModule(reactContext),
                 new FBGameRequestDialogModule(reactContext, mActivityEventListener),
                 new FBGraphRequestModule(reactContext),
                 new FBLoginManagerModule(reactContext, mActivityEventListener),

--- a/ios/RCTFBSDK.xcodeproj/project.pbxproj
+++ b/ios/RCTFBSDK.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		93E005141CE3D2D3000598E3 /* RCTFBSDKShareButtonManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E005061CE3D2D3000598E3 /* RCTFBSDKShareButtonManager.m */; };
 		93E005151CE3D2D3000598E3 /* RCTFBSDKShareDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E005081CE3D2D3000598E3 /* RCTFBSDKShareDialog.m */; };
 		93E005161CE3D2D3000598E3 /* RCTFBSDKShareHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E0050A1CE3D2D3000598E3 /* RCTFBSDKShareHelper.m */; };
+		F1191EC92560474100A8767F /* RCTFBSDKAppLink.m in Sources */ = {isa = PBXBuildFile; fileRef = F1191EC82560474100A8767F /* RCTFBSDKAppLink.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -77,6 +78,8 @@
 		93E005081CE3D2D3000598E3 /* RCTFBSDKShareDialog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKShareDialog.m; path = share/RCTFBSDKShareDialog.m; sourceTree = "<group>"; };
 		93E005091CE3D2D3000598E3 /* RCTFBSDKShareHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKShareHelper.h; path = share/RCTFBSDKShareHelper.h; sourceTree = "<group>"; };
 		93E0050A1CE3D2D3000598E3 /* RCTFBSDKShareHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKShareHelper.m; path = share/RCTFBSDKShareHelper.m; sourceTree = "<group>"; };
+		F1191EC82560474100A8767F /* RCTFBSDKAppLink.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKAppLink.m; path = core/RCTFBSDKAppLink.m; sourceTree = "<group>"; };
+		F1191ECB25604E4B00A8767F /* RCTFBSDKAppLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKAppLink.h; path = core/RCTFBSDKAppLink.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -143,6 +146,8 @@
 				93E004E01CE3D292000598E3 /* RCTFBSDKAppEvents.m */,
 				93E004E11CE3D292000598E3 /* RCTFBSDKGraphRequestManager.h */,
 				93E004E21CE3D292000598E3 /* RCTFBSDKGraphRequestManager.m */,
+				F1191ECB25604E4B00A8767F /* RCTFBSDKAppLink.h */,
+				F1191EC82560474100A8767F /* RCTFBSDKAppLink.m */,
 			);
 			name = core;
 			sourceTree = "<group>";
@@ -254,6 +259,7 @@
 				93E005141CE3D2D3000598E3 /* RCTFBSDKShareButtonManager.m in Sources */,
 				93E005131CE3D2D3000598E3 /* RCTFBSDKShareAPI.m in Sources */,
 				93E004F11CE3D2B4000598E3 /* RCTFBSDKLoginManager.m in Sources */,
+				F1191EC92560474100A8767F /* RCTFBSDKAppLink.m in Sources */,
 				93E005121CE3D2D3000598E3 /* RCTFBSDKSendButtonManager.m in Sources */,
 				93B905C21D2D987F0013CC92 /* RCTFBSDKGraphRequestConnectionContainer.m in Sources */,
 			);

--- a/ios/RCTFBSDK/core/RCTFBSDKAppLink.h
+++ b/ios/RCTFBSDK/core/RCTFBSDKAppLink.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import <React/RCTBridgeModule.h>
+
+#import <FBSDKCoreKit/FBSDKCoreKit.h>
+
+@interface RCTFBSDKAppLink : NSObject <RCTBridgeModule>
+@end

--- a/ios/RCTFBSDK/core/RCTFBSDKAppLink.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKAppLink.m
@@ -1,0 +1,52 @@
+// Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "RCTFBSDKAppLink.h"
+
+#import <React/RCTUtils.h>
+
+@implementation RCTFBSDKAppLink
+
+RCT_EXPORT_MODULE(FBAppLink);
+
+- (dispatch_queue_t)methodQueue
+{
+  return dispatch_get_main_queue();
+}
+
+#pragma mark - React Native Methods
+
+RCT_REMAP_METHOD(fetchDeferredAppLink,
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [FBSDKAppLinkUtility fetchDeferredAppLink:^(NSURL *url, NSError *error) {
+    if (error) {
+      NSLog(@"Received error while fetching deferred app link %@", error);
+    }
+
+    if (url) {
+      NSString* appLink = [NSString stringWithFormat:@"%@", url];
+      resolve(appLink);
+    }else{
+      resolve(nil);
+    }
+  }];
+}
+
+@end

--- a/src/FBAppLink.js
+++ b/src/FBAppLink.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @flow
+ * @format
+ */
+'use strict';
+
+const AppLink = require('react-native').NativeModules.FBAppLink;
+
+module.exports = {
+  fetchDeferredAppLink(): Promise<string | null> {
+    return AppLink.fetchDeferredAppLink();
+  },
+};

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,9 @@ module.exports = {
   get AppEventsLogger() {
     return require('./FBAppEventsLogger');
   },
+  get AppLink() {
+    return require('./FBAppLink');
+  },
   get GameRequestDialog() {
     return require('./FBGameRequestDialog');
   },


### PR DESCRIPTION
### About

Using facebook deferred app link in react-native project was a bit painful, because it isn't included in react-native-fbsdk.

Simply warp the `fetchDeferredAppLink` function from native.

#### iOS
1. Use `fetchDeferredAppLink` from [FBSDKAppLinkUtility](https://developers.facebook.com/docs/reference/ios/current/class/FBSDKAppLinkUtility)
2. Convert app link url from `NSURL` to `NSString` if app link is found and pass it to JS using `RCTPromiseResolveBlock`.
3. Resolve `null` if app link is not found. 

#### Android
1. Use `fetchDeferredAppLinkData` from [AppLinkData](https://developers.facebook.com/docs/reference/androidsdk/current/facebook/com/facebook/applinks/applinkdata.html)
2. If `appLinkData` is found, convert its `Uri` to `String` and pass it to JS using `com.facebook.react.bridge.Promise`. 
3. Resolve `null` if `appLinkData` is not found. 


### Test Plan:

Check if `AppLink.fetchDeferredAppLink` is working as expected

Example code
```JavaScript
import { AppLink } from 'react-native-fbsdk';

const link = await AppLink.fetchDeferredAppLink();

console.log(link); // should be a string or null
```
