### PR TITLE
Fix Xcode 12 compatibility

### DIFF
--- a/react-native-fbsdk.podspec
+++ b/react-native-fbsdk.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.homepage      = package['homepage']
   s.source        = { :git => 'https://github.com/facebook/react-native-fbsdk.git', :tag => "v#{package['version']}" }
   s.platforms     = { :ios => "9.0", :tvos => "9.2" }
-  s.dependency      'React'
+  s.dependency      'React-Core'
 
   s.subspec 'Core' do |ss|
     ss.dependency     'FBSDKCoreKit', '~> 8.1'


### PR DESCRIPTION
Compilation fails on Xcode 12 with `Undefined symbols for architecture` errors, due to the React dependency in the podspec.

See the react-native issue here - https://github.com/facebook/react-native/issues/29633#issuecomment-694187116