### PR TITLE
The README file in this repo has 4 bad links - [404:NotFound]

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ shareLinkWithShareDialog() {
 
 #### Share Photos
 
-See [SharePhotoContent](/js/models/FBSharePhotoContent.js) and [SharePhoto](/js/models/FBSharePhoto.js) to refer other options.
+See [SharePhotoContent](/src/models/FBSharePhotoContent.js) and [SharePhoto](/src/models/FBSharePhoto.js) to refer other options.
 
 ```js
 const FBSDK = require('react-native-fbsdk');
@@ -297,7 +297,7 @@ ShareDialog.show(tmp.state.sharePhotoContent);
 
 #### Share Videos
 
-See [ShareVideoContent](/js/models/FBShareVideoContent.js) and [ShareVideo](/js/models/FBShareVideo.js) to refer other options.
+See [ShareVideoContent](/src/models/FBShareVideoContent.js) and [ShareVideo](/src/models/FBShareVideo.js) to refer other options.
 
 ```js
 const FBSDK = require('react-native-fbsdk');


### PR DESCRIPTION
The markup version of the readme that is displayed for the main page in this repo contains the following bad links:

Status code [404:NotFound] - Link: https://github.com/facebook/react-native-fbsdk/blob/master/js/models/FBSharePhotoContent.js
Status code [404:NotFound] - Link: https://github.com/facebook/react-native-fbsdk/blob/master/js/models/FBSharePhoto.js
Status code [404:NotFound] - Link: https://github.com/facebook/react-native-fbsdk/blob/master/js/models/FBShareVideoContent.js
Status code [404:NotFound] - Link: https://github.com/facebook/react-native-fbsdk/blob/master/js/models/FBShareVideo.js

It looks the in the path "js" should be replaced with "src"

**Extra**

Theses bad links were found by a tool I recently created as part of an new experimental hobby project: https://github.com/MrCull/GitHub-Repo-ReadMe-Dead-Link-Finder

Re-check this Repo using the tool’s website: http://githubreadmechecker.com/Home/Search?SingleRepoUri=https%3a%2f%2fgithub.com%2ffacebook%2freact-native-fbsdk

If you have any feedback on the tool itself, or the information provided here, then please feel free to share your thoughts by adding a comment here, or adding a “Discussions” comment in the tool’s Repo.

