### PR TITLE
Added setAutoLogAppEventsEnabled

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSettingsModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSettingsModule.java
@@ -49,4 +49,13 @@ public class FBSettingsModule extends BaseJavaModule {
     public static void setDataProcessingOptionsExtra(@Nullable String[] options, int country, int state) {
         FacebookSdk.setDataProcessingOptions(options, country, state);
     }
+
+    /**
+     * Sets auto log events flag
+     * @param enabled flag setting
+     */
+    @ReactMethod
+    public static void setAutoLogAppEventsEnabled(boolean enabled) {
+        FacebookSdk.setAutoLogAppEventsEnabled(enabled);
+    }
 }

--- a/ios/RCTFBSDK/core/RCTFBSDKSettings.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKSettings.m
@@ -43,4 +43,9 @@ RCT_EXPORT_METHOD(setDataProcessingOptions:(nullable NSStringArray *)options cou
   [FBSDKSettings setDataProcessingOptions:options country:country state:state];
 }
 
+RCT_EXPORT_METHOD(setAutoLogAppEventsEnabled:(BOOL)ALE)
+{
+  [FBSDKSettings setAutoLogAppEventsEnabled:ALE];
+}
+
 @end

--- a/src/FBSettings.js
+++ b/src/FBSettings.js
@@ -52,4 +52,10 @@ module.exports = {
     }
     Settings.setDataProcessingOptions(options, country, state);
   },
+  /**
+   * Set auto log app events
+   */
+  setAutoLogAppEventsEnabled(ALE: boolean) {
+    Settings.setAutoLogAppEventsEnabled(ALE);
+  }
 };


### PR DESCRIPTION
Fixes #461 

Test Plan:

Integrate the SDK into the project, set AutoLogAppEventsEnabled false in info.plist and AndroidManifest.xml and then call `Settings.setAutoLogAppEventsEnabled(true)`

You can then verify using the Events Manager that the auto events (App Installs, Launches, etc) will start showing up. 
 