### PR TITLE
Change the Facebook SDK to version 9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,6 +43,7 @@ repositories {
     }
     google()
     jcenter()
+    mavenCentral()
 }
 
 def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', '9.0.+')

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,7 @@ repositories {
     jcenter()
 }
 
-def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', '[7.1.0, 9)')
+def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', '9')
 
 dependencies {
     //noinspection GradleDynamicVersion

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,7 @@ repositories {
     jcenter()
 }
 
-def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', '9')
+def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', '9.0.+')
 
 dependencies {
     //noinspection GradleDynamicVersion

--- a/react-native-fbsdk.podspec
+++ b/react-native-fbsdk.podspec
@@ -14,17 +14,17 @@ Pod::Spec.new do |s|
   s.dependency      'React'
 
   s.subspec 'Core' do |ss|
-    ss.dependency     'FBSDKCoreKit', '~> 8.1'
+    ss.dependency     'FBSDKCoreKit', '~> 9.0'
     ss.source_files = 'ios/RCTFBSDK/core/*.{h,m}'
   end
 
   s.subspec 'Login' do |ss|
-    ss.dependency     'FBSDKLoginKit', '~> 8.1'
+    ss.dependency     'FBSDKLoginKit', '~> 9.0'
     ss.source_files = 'ios/RCTFBSDK/login/*.{h,m}'
   end
 
   s.subspec 'Share' do |ss|
-    ss.dependency     'FBSDKShareKit', '~> 8.1'
+    ss.dependency     'FBSDKShareKit', '~> 9.0'
     ss.source_files = 'ios/RCTFBSDK/share/*.{h,m}'
   end
 end


### PR DESCRIPTION
Change the Facebook SDK to version 9. Given there is no breaking changes, all API should work as previous.

Fixes #832