### PR TITLE
Error Typo In ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ export default class Login extends Component {
           onLoginFinished={
             (error, result) => {
               if (error) {
-                console.log("login has error: " + result.error);
+                console.log("login has error: " + error);
               } else if (result.isCancelled) {
                 console.log("login is cancelled.");
               } else {


### PR DESCRIPTION
I Just Got In error While Setting Up facebook Auth Button I Got Development Error But On Readme Doc on OnLoginFinished Callback It Was a typo which would have to be console.log("App has error ",  error) instead it was console.log("App has error" , result.error) as it was Undefined
