### PR TITLE
[Fix] Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,9 @@ shareLinkWithShareDialog() {
 }
 ```
 
-#### Share Photos
+#### Share Photos (Removed from `react-native-fbsdk` 1.1.2)
+
+* Use [Share dialogs](#Sharing) instead.
 
 See [SharePhotoContent](/js/models/FBSharePhotoContent.js) and [SharePhoto](/js/models/FBSharePhoto.js) to refer other options.
 
@@ -295,7 +297,9 @@ const sharePhotoContent = {
 ShareDialog.show(tmp.state.sharePhotoContent);
 ```
 
-#### Share Videos
+#### Share Videos (Removed from `react-native-fbsdk` 1.1.2)
+
+* Use [Share dialogs](#Sharing) instead.
 
 See [ShareVideoContent](/js/models/FBShareVideoContent.js) and [ShareVideo](/js/models/FBShareVideo.js) to refer other options.
 
@@ -316,7 +320,9 @@ const shareVideoContent = {
 ShareDialog.show(tmp.state.shareVideoContent);
 ```
 
-#### Share API
+#### Share API (Removed from `react-native-fbsdk` 1.1.2)
+
+* Use [Share dialogs](#Sharing) instead.
 
 Your app must have the `publish_actions` permission approved to share through the share API. You should prefer to use the Share Dialogs for an easier and more consistent experience.
 


### PR DESCRIPTION
`Share Api` has been removed from `react-native-fbsdk` by [this commit](https://github.com/facebook/react-native-fbsdk/commit/0a684bea321912ee1313caaa6c4b6d90941971ce). 

but, It still exist on README.md file. So, I marked 'removed' on README.

Related Issue: #781